### PR TITLE
[controller] Fixed free space calculation logic for PVCs using the same storage class

### DIFF
--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
@@ -103,7 +103,7 @@ func scoreNodes(
 		return nil, err
 	}
 
-	scLVGs, err := getLVGsFromStorageClasses(scs)
+	scLVGs, err := getSortedLVGsFromStorageClasses(scs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Fixed free space calculation logic for PVCs using the same storage class. 

## Why do we need it, and what problem does it solve?
It solves the problem with insufficient free space for PVCs using the same storage class. Before it was counted for each one independently.

## What is the expected result?
A pod with several PVCs using the same storage class will not be scheduled, if there is not enough free space on the node for all PVCs.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
