### PR TITLE
[contoller] Add a possibility to edit a LocalStorageClass spec.lvm.LVMVolumeGroups to configure an appropriate Storage Class.

### DIFF
--- a/crds/localstorageclass.yaml
+++ b/crds/localstorageclass.yaml
@@ -96,9 +96,6 @@ spec:
                         - Thin
                     lvmVolumeGroups:
                       type: array
-                      x-kubernetes-validations:
-                        - rule: self == oldSelf
-                          message: Value is immutable.
                       description: |
                         LVMVolumeGroup resources where Persistent Volume will be create on.
                       items:

--- a/images/sds-local-volume-controller/cmd/main.go
+++ b/images/sds-local-volume-controller/cmd/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	log.Info("[main] CfgParams has been successfully created")
 	log.Info(fmt.Sprintf("[main] %s = %s", config.LogLevel, cfgParams.Loglevel))
-	log.Info(fmt.Sprintf("[main] %s = %s", config.RequeueInterval, cfgParams.RequeueInterval.String()))
+	log.Info(fmt.Sprintf("[main] %s = %d", config.RequeueInterval, cfgParams.RequeueInterval))
 
 	kConfig, err := kubutils.KubernetesDefaultConfigCreate()
 	if err != nil {

--- a/images/sds-local-volume-controller/pkg/config/config.go
+++ b/images/sds-local-volume-controller/pkg/config/config.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	NodeName        = "KUBE_NODE_NAME"
 	LogLevel        = "LOG_LEVEL"
 	RequeueInterval = "REQUEUE_INTERVAL"
 )
@@ -40,7 +39,7 @@ func NewConfig() *Options {
 		opts.Loglevel = logger.Verbosity(loglevel)
 	}
 
-	opts.RequeueInterval = 5
+	opts.RequeueInterval = 10
 
 	return &opts
 }


### PR DESCRIPTION
## Description
Add a possibility to edit a LocalStorageClass spec.lvm.LVMVolumeGroups resources to configure an appropriate Storage Class.
Now if the resource validation fails, the controller will add a request to requeue until the resource is fixed or deleted.

## Why do we need it, and what problem does it solve?
A user has a possibility to change LVMVolumeGroups using by a Storage Class.
If a user fixes the LocalStorageClass validation failure, the controller will continue the work automatically.

## What is the expected result?
A LocalStorageClass spec.lvm.LVMVolumeGroups editing provides an appropriate Storage Class recreation with actual LVMVolumeGroups.
If the validation of the Local Storage Class resource fails, the controller will retry processing the resource until it succeeds or the problematic resource is deleted.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
