### PR TITLE
[csi] Add field ActualLVNameOnTheNode. Add SDSLocalVolumeCSIFinalizer. Add delete LVMLogicalVolume after error in CreateVolume. Bump go builder to 1.21

### DIFF
--- a/images/sds-local-volume-csi/Dockerfile
+++ b/images/sds-local-volume-csi/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_ALPINE=registry.deckhouse.io/base_images/alpine:3.16.3@sha256:5548e9172c24a1b0ca9afdd2bf534e265c94b12b36b3e0c0302f5853eaf00abb
-ARG BASE_GOLANG_20_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.20.5-alpine3.18@sha256:51a47fb0851397db2f506c15c426735bc23de31177cbdd962880c0879d1906a4
+ARG BASE_GOLANG_21_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.21.4-alpine3.18@sha256:cf84f3d6882c49ea04b6478ac514a2582c8922d7e5848b43d2918fff8329f6e6
 
-FROM $BASE_GOLANG_20_ALPINE_BUILDER as builder
+FROM $BASE_GOLANG_21_ALPINE_BUILDER as builder
 
 WORKDIR /go/src
 

--- a/images/sds-local-volume-csi/api/v1alpha1/lvm_logical_volume.go
+++ b/images/sds-local-volume-csi/api/v1alpha1/lvm_logical_volume.go
@@ -37,10 +37,11 @@ type LVMLogicalVolume struct {
 }
 
 type LVMLogicalVolumeSpec struct {
-	Type           string                 `json:"type"`
-	Size           resource.Quantity      `json:"size"`
-	LvmVolumeGroup string                 `json:"lvmVolumeGroup"`
-	Thin           *ThinLogicalVolumeSpec `json:"thin"`
+	ActualLVNameOnTheNode string                 `json:"actualLVNameOnTheNode"`
+	Type                  string                 `json:"type"`
+	Size                  resource.Quantity      `json:"size"`
+	LvmVolumeGroupName    string                 `json:"lvmVolumeGroupName"`
+	Thin                  *ThinLogicalVolumeSpec `json:"thin"`
 }
 
 type ThinLogicalVolumeSpec struct {

--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -66,7 +66,12 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		d.log.Error(err, "error GetStorageClassLVGs")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
-
+// TODO: Consider refactoring the naming strategy for llvName and lvName.
+// Currently, we use the same name for llvName (the name of the LVMLogicalVolume resource in Kubernetes)
+// and lvName (the name of the LV in LVM on the node) because the PV name is unique within the cluster,
+// preventing name collisions. This approach simplifies matching between nodes and Kubernetes by maintaining
+// the same name in both contexts. Future consideration should be given to optimizing this logic to enhance
+// code readability and maintainability.
 	llvName := request.Name
 	lvName := request.Name
 	d.log.Info(fmt.Sprintf("llv name: %s ", llvName))


### PR DESCRIPTION
### Description:
This PR introduces several enhancements and fixes:

- **ActualLVNameOnTheNode Field:** Synchronized the `ActualLVNameOnTheNode` field in the `LVMLogicalVolume` spec with the design documentation to ensure consistency.
- **SDSLocalVolumeCSIFinalizer:** Implemented a dedicated finalizer for CSI within `LVMLogicalVolume` to prevent the deletion of Logical Volumes (LV) on nodes if the CSI finalizer has not been removed. This addition aims to enhance the management and cleanup of resources.
- **Deletion of LVMLogicalVolume on CreateVolume Error:** Added logic to delete the `LVMLogicalVolume` resource if an error occurs during the `CreateVolume` operation, improving error handling and resource cleanup.
- **Go Builder Version Bump to 1.21:** Updated the Go builder version to 1.21 to leverage new Go features and improvements.


### What is the expected result?
- Improved consistency between the LVMLogicalVolume spec and design documentation.
- Enhanced resource lifecycle management with the new finalizer, preventing premature LV deletions.
- Better error handling through automatic cleanup of resources upon failure in volume creation.
- Utilization of Go 1.21 features for development, resulting in more efficient and reliable code.

### Checklist:
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.