### PR TITLE
[controller] Fix max volumes per node and R/W map

### DIFF
--- a/images/sds-local-volume-csi/driver/node.go
+++ b/images/sds-local-volume-csi/driver/node.go
@@ -142,8 +142,8 @@ func (d *Driver) NodeGetInfo(ctx context.Context, request *csi.NodeGetInfoReques
 	d.log.Info("hostID = ", d.hostID)
 
 	return &csi.NodeGetInfoResponse{
-		NodeId:            d.hostID,
-		MaxVolumesPerNode: 10,
+		NodeId: d.hostID,
+		//MaxVolumesPerNode: 10,
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
 				internal.TopologyKey: d.hostID,


### PR DESCRIPTION
Signed-off-by: Viktor Kramarenko <viktor.kramarenko@flant.com>

## Description
In a really high PVC amount scenario there is a chance to face Volume limit and concurrent map access problems.

## Why do we need it, and what problem does it solve?
It solves the volume limit and concurrent map access problems.

## What is the expected result?
Any amount of volumes might be attached to a node. No errors with concurrent map access.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
