### PR TITLE
[controller] Change LVMVolumeGroup size field type from string to quantity

### DIFF
--- a/images/sds-local-volume-controller/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-local-volume-controller/api/v1alpha1/lvm_volume_group.go
@@ -48,7 +48,7 @@ type LvmVolumeGroupSpec struct {
 type LvmVolumeGroupDevice struct {
 	BlockDevice string            `json:"blockDevice"`
 	DevSize     resource.Quantity `json:"devSize"`
-	PVSize      string            `json:"pvSize"`
+	PVSize      resource.Quantity `json:"pvSize"`
 	PVUuid      string            `json:"pvUUID"`
 	Path        string            `json:"path"`
 }
@@ -61,15 +61,15 @@ type LvmVolumeGroupNode struct {
 type StatusThinPool struct {
 	Name       string            `json:"name"`
 	ActualSize resource.Quantity `json:"actualSize"`
-	UsedSize   string            `json:"usedSize"`
+	UsedSize   resource.Quantity `json:"usedSize"`
 }
 
 type LvmVolumeGroupStatus struct {
-	AllocatedSize string               `json:"allocatedSize"`
+	AllocatedSize resource.Quantity    `json:"allocatedSize"`
 	Health        string               `json:"health"`
 	Message       string               `json:"message"`
 	Nodes         []LvmVolumeGroupNode `json:"nodes"`
 	ThinPools     []StatusThinPool     `json:"thinPools"`
-	VGSize        string               `json:"vgSize"`
+	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
 }

--- a/images/sds-local-volume-csi/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-local-volume-csi/api/v1alpha1/lvm_volume_group.go
@@ -51,7 +51,7 @@ type LvmVolumeGroupSpec struct {
 type LvmVolumeGroupDevice struct {
 	BlockDevice string            `json:"blockDevice"`
 	DevSize     resource.Quantity `json:"devSize"`
-	PVSize      string            `json:"pvSize"`
+	PVSize      resource.Quantity `json:"pvSize"`
 	PVUuid      string            `json:"pvUUID"`
 	Path        string            `json:"path"`
 }
@@ -64,15 +64,15 @@ type LvmVolumeGroupNode struct {
 type StatusThinPool struct {
 	Name       string            `json:"name"`
 	ActualSize resource.Quantity `json:"actualSize"`
-	UsedSize   string            `json:"usedSize"`
+	UsedSize   resource.Quantity `json:"usedSize"`
 }
 
 type LvmVolumeGroupStatus struct {
-	AllocatedSize string               `json:"allocatedSize"`
+	AllocatedSize resource.Quantity    `json:"allocatedSize"`
 	Health        string               `json:"health"`
 	Message       string               `json:"message"`
 	Nodes         []LvmVolumeGroupNode `json:"nodes"`
 	ThinPools     []StatusThinPool     `json:"thinPools"`
-	VGSize        string               `json:"vgSize"`
+	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
 }

--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -66,12 +66,12 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		d.log.Error(err, "error GetStorageClassLVGs")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
-// TODO: Consider refactoring the naming strategy for llvName and lvName.
-// Currently, we use the same name for llvName (the name of the LVMLogicalVolume resource in Kubernetes)
-// and lvName (the name of the LV in LVM on the node) because the PV name is unique within the cluster,
-// preventing name collisions. This approach simplifies matching between nodes and Kubernetes by maintaining
-// the same name in both contexts. Future consideration should be given to optimizing this logic to enhance
-// code readability and maintainability.
+	// TODO: Consider refactoring the naming strategy for llvName and lvName.
+	// Currently, we use the same name for llvName (the name of the LVMLogicalVolume resource in Kubernetes)
+	// and lvName (the name of the LV in LVM on the node) because the PV name is unique within the cluster,
+	// preventing name collisions. This approach simplifies matching between nodes and Kubernetes by maintaining
+	// the same name in both contexts. Future consideration should be given to optimizing this logic to enhance
+	// code readability and maintainability.
 	llvName := request.Name
 	lvName := request.Name
 	d.log.Info(fmt.Sprintf("llv name: %s ", llvName))
@@ -302,10 +302,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.Contro
 	}
 
 	if llv.Spec.Type == internal.LLMTypeThick {
-		lvgFreeSpace, err := utils.GetLVMVolumeGroupFreeSpace(*lvg)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "error getting LVMVolumeGroupCapacity: %v", err)
-		}
+		lvgFreeSpace := utils.GetLVMVolumeGroupFreeSpace(*lvg)
 
 		if lvgFreeSpace.Value() < (requestCapacity.Value() - llv.Status.ActualSize.Value()) {
 			return nil, status.Errorf(codes.Internal, "requested size: %s is greater than the capacity of the LVMVolumeGroup: %s", requestCapacity.String(), lvgFreeSpace.String())

--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -83,7 +83,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 	switch BindingMode {
 	case internal.BindingModeI:
 		d.log.Info(fmt.Sprintf("BindingMode is %s. Start selecting node", internal.BindingModeI))
-		selectedNodeName, freeSpace, err := utils.GetNodeWithMaxFreeSpace(d.log, storageClassLVGs, storageClassLVGParametersMap, LvmType)
+		selectedNodeName, freeSpace, err := utils.GetNodeWithMaxFreeSpace(storageClassLVGs, storageClassLVGParametersMap, LvmType)
 		if err != nil {
 			d.log.Error(err, "error GetNodeMaxVGSize")
 		}
@@ -103,13 +103,13 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		}
 	}
 
-	selectedLVG, err := utils.SelectLVG(storageClassLVGs, storageClassLVGParametersMap, preferredNode)
+	selectedLVG, err := utils.SelectLVG(storageClassLVGs, preferredNode)
 	if err != nil {
 		d.log.Error(err, "error SelectLVG")
 		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
-	llvSpec := utils.GetLLVSpec(d.log, lvName, selectedLVG, storageClassLVGParametersMap, preferredNode, LvmType, *llvSize)
+	llvSpec := utils.GetLLVSpec(d.log, lvName, selectedLVG, storageClassLVGParametersMap, LvmType, *llvSize)
 	d.log.Info(fmt.Sprintf("LVMLogicalVolumeSpec : %+v", llvSpec))
 	resizeDelta, err := resource.ParseQuantity(internal.ResizeDelta)
 	if err != nil {

--- a/images/sds-local-volume-csi/pkg/utils/func.go
+++ b/images/sds-local-volume-csi/pkg/utils/func.go
@@ -277,6 +277,7 @@ func GetLVMThinPoolFreeSpace(lvg v1alpha1.LvmVolumeGroup, thinPoolName string) (
 	for _, thinPool := range lvg.Status.ThinPools {
 		if thinPool.Name == thinPoolName {
 			storagePoolThinPool = &thinPool
+			break
 		}
 	}
 

--- a/images/sds-local-volume-csi/pkg/utils/func.go
+++ b/images/sds-local-volume-csi/pkg/utils/func.go
@@ -171,8 +171,7 @@ func AreSizesEqualWithinDelta(leftSize, rightSize, allowedDelta resource.Quantit
 	return math.Abs(leftSizeFloat-rightSizeFloat) < float64(allowedDelta.Value())
 }
 
-func GetNodeWithMaxFreeSpace(log *logger.Logger, lvgs []v1alpha1.LvmVolumeGroup, storageClassLVGParametersMap map[string]string, lvmType string) (nodeName string, freeSpace resource.Quantity, err error) {
-
+func GetNodeWithMaxFreeSpace(lvgs []v1alpha1.LvmVolumeGroup, storageClassLVGParametersMap map[string]string, lvmType string) (nodeName string, freeSpace resource.Quantity, err error) {
 	var maxFreeSpace int64
 	for _, lvg := range lvgs {
 
@@ -365,7 +364,7 @@ func GetLVGList(ctx context.Context, kc client.Client) (*v1alpha1.LvmVolumeGroup
 	return nil, fmt.Errorf("after %d attempts of getting LvmVolumeGroupList, last error: %w", KubernetesApiRequestLimit, err)
 }
 
-func GetLLVSpec(log *logger.Logger, lvName string, selectedLVG v1alpha1.LvmVolumeGroup, storageClassLVGParametersMap map[string]string, nodeName, lvmType string, llvSize resource.Quantity) v1alpha1.LVMLogicalVolumeSpec {
+func GetLLVSpec(log *logger.Logger, lvName string, selectedLVG v1alpha1.LvmVolumeGroup, storageClassLVGParametersMap map[string]string, lvmType string, llvSize resource.Quantity) v1alpha1.LVMLogicalVolumeSpec {
 	var llvThin *v1alpha1.ThinLogicalVolumeSpec
 	if lvmType == internal.LLMTypeThin {
 		llvThin = &v1alpha1.ThinLogicalVolumeSpec{}
@@ -381,7 +380,7 @@ func GetLLVSpec(log *logger.Logger, lvName string, selectedLVG v1alpha1.LvmVolum
 	}
 }
 
-func SelectLVG(storageClassLVGs []v1alpha1.LvmVolumeGroup, storageClassLVGParametersMap map[string]string, nodeName string) (v1alpha1.LvmVolumeGroup, error) {
+func SelectLVG(storageClassLVGs []v1alpha1.LvmVolumeGroup, nodeName string) (v1alpha1.LvmVolumeGroup, error) {
 	for _, lvg := range storageClassLVGs {
 		if lvg.Status.Nodes[0].Name == nodeName {
 			return lvg, nil

--- a/images/sds-local-volume-scheduler-extender/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-local-volume-scheduler-extender/api/v1alpha1/lvm_volume_group.go
@@ -48,7 +48,7 @@ type LvmVolumeGroupSpec struct {
 type LvmVolumeGroupDevice struct {
 	BlockDevice string            `json:"blockDevice"`
 	DevSize     resource.Quantity `json:"devSize"`
-	PVSize      string            `json:"pvSize"`
+	PVSize      resource.Quantity `json:"pvSize"`
 	PVUuid      string            `json:"pvUUID"`
 	Path        string            `json:"path"`
 }
@@ -61,15 +61,15 @@ type LvmVolumeGroupNode struct {
 type StatusThinPool struct {
 	Name       string            `json:"name"`
 	ActualSize resource.Quantity `json:"actualSize"`
-	UsedSize   string            `json:"usedSize"`
+	UsedSize   resource.Quantity `json:"usedSize"`
 }
 
 type LvmVolumeGroupStatus struct {
-	AllocatedSize string               `json:"allocatedSize"`
+	AllocatedSize resource.Quantity    `json:"allocatedSize"`
 	Health        string               `json:"health"`
 	Message       string               `json:"message"`
 	Nodes         []LvmVolumeGroupNode `json:"nodes"`
 	ThinPools     []StatusThinPool     `json:"thinPools"`
-	VGSize        string               `json:"vgSize"`
+	VGSize        resource.Quantity    `json:"vgSize"`
 	VGUuid        string               `json:"vgUUID"`
 }

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
@@ -106,28 +106,8 @@ func RunLVGWatcherCacheController(
 			}
 
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] starts to calculate the size difference for LVMVolumeGroup %s", newLvg.Name))
-			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] old state LVMVolumeGroup %s has size %s", oldLvg.Name, oldLvg.Status.AllocatedSize))
-
-			//var oldSize resource.Quantity
-			//if oldLvg.Status.AllocatedSize != "" {
-			//	oldSize, err = resource.ParseQuantity(oldLvg.Status.AllocatedSize)
-			//	if err != nil {
-			//		log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to parse the allocated size for the LVMVolumeGroup %s", oldLvg.Name))
-			//		return
-			//	}
-			//}
-			//
-			//log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] new state LVMVolumeGroup %s has size %s", newLvg.Name, newLvg.Status.AllocatedSize))
-			//if newLvg.Status.AllocatedSize == "" {
-			//	log.Warning(fmt.Sprintf("LVMVolumeGroup %s new state has uninitialized allocated size field. Reconciliation will be skipped", newLvg.Name))
-			//	return
-			//}
-			////newSize, err := resource.ParseQuantity(newLvg.Status.AllocatedSize)
-			//if err != nil {
-			//	log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to parse the allocated size for the LVMVolumeGroup %s", oldLvg.Name))
-			//	return
-			//}
-			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] successfully calculated the size difference for LVMVolumeGroup %s", newLvg.Name))
+			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] old state LVMVolumeGroup %s has size %s", oldLvg.Name, oldLvg.Status.AllocatedSize.String()))
+			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] new state LVMVolumeGroup %s has size %s", newLvg.Name, newLvg.Status.AllocatedSize.String()))
 
 			if newLvg.DeletionTimestamp != nil ||
 				oldLvg.Status.AllocatedSize.Value() == newLvg.Status.AllocatedSize.Value() {

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/util/workqueue"
 	"sds-local-volume-scheduler-extender/api/v1alpha1"
 	"sds-local-volume-scheduler-extender/pkg/cache"
@@ -107,23 +106,31 @@ func RunLVGWatcherCacheController(
 			}
 
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] starts to calculate the size difference for LVMVolumeGroup %s", newLvg.Name))
-			oldSize, err := resource.ParseQuantity(oldLvg.Status.AllocatedSize)
-			if err != nil {
-				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to parse the allocated size for the LVMVolumeGroup %s", oldLvg.Name))
-				return
-			}
-			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] old state LVMVolumeGroup %s has size %s", oldLvg.Name, oldSize.String()))
+			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] old state LVMVolumeGroup %s has size %s", oldLvg.Name, oldLvg.Status.AllocatedSize))
 
-			newSize, err := resource.ParseQuantity(newLvg.Status.AllocatedSize)
-			if err != nil {
-				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to parse the allocated size for the LVMVolumeGroup %s", oldLvg.Name))
-				return
-			}
-			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] new state LVMVolumeGroup %s has size %s", newLvg.Name, newSize.String()))
+			//var oldSize resource.Quantity
+			//if oldLvg.Status.AllocatedSize != "" {
+			//	oldSize, err = resource.ParseQuantity(oldLvg.Status.AllocatedSize)
+			//	if err != nil {
+			//		log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to parse the allocated size for the LVMVolumeGroup %s", oldLvg.Name))
+			//		return
+			//	}
+			//}
+			//
+			//log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] new state LVMVolumeGroup %s has size %s", newLvg.Name, newLvg.Status.AllocatedSize))
+			//if newLvg.Status.AllocatedSize == "" {
+			//	log.Warning(fmt.Sprintf("LVMVolumeGroup %s new state has uninitialized allocated size field. Reconciliation will be skipped", newLvg.Name))
+			//	return
+			//}
+			////newSize, err := resource.ParseQuantity(newLvg.Status.AllocatedSize)
+			//if err != nil {
+			//	log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to parse the allocated size for the LVMVolumeGroup %s", oldLvg.Name))
+			//	return
+			//}
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] successfully calculated the size difference for LVMVolumeGroup %s", newLvg.Name))
 
 			if newLvg.DeletionTimestamp != nil ||
-				oldSize.Value() == newSize.Value() {
+				oldLvg.Status.AllocatedSize.Value() == newLvg.Status.AllocatedSize.Value() {
 				log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] the LVMVolumeGroup %s should not be reconciled", newLvg.Name))
 				return
 			}

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter.go
@@ -292,10 +292,7 @@ func filterNodes(
 		log.Trace(fmt.Sprintf("[filterNodes] the LVMVolumeGroup %s is actually used. VG size: %s, allocatedSize: %s", lvg.Name, lvg.Status.VGSize, lvg.Status.AllocatedSize))
 	}
 
-	lvgsThickFree, err := getLVGThickFreeSpaces(log, usedLVGs)
-	if err != nil {
-		return nil, err
-	}
+	lvgsThickFree := getLVGThickFreeSpaces(log, usedLVGs)
 	log.Trace(fmt.Sprintf("[filterNodes] for a Pod %s/%s current LVMVolumeGroups Thick FreeSpace on the node: %+v", pod.Namespace, pod.Name, lvgsThickFree))
 
 	for lvgName, freeSpace := range lvgsThickFree {
@@ -440,21 +437,18 @@ func filterNodes(
 	return result, nil
 }
 
-func getLVGThickFreeSpaces(log logger.Logger, lvgs map[string]*v1alpha1.LvmVolumeGroup) (map[string]int64, error) {
+func getLVGThickFreeSpaces(log logger.Logger, lvgs map[string]*v1alpha1.LvmVolumeGroup) map[string]int64 {
 	result := make(map[string]int64, len(lvgs))
 
 	for _, lvg := range lvgs {
 		log.Debug(fmt.Sprintf("[getLVGThickFreeSpaces] tries to count free VG space for LVMVolumeGroup %s", lvg.Name))
-		free, err := getVGFreeSpace(lvg)
-		if err != nil {
-			return nil, err
-		}
+		free := getVGFreeSpace(lvg)
 		log.Debug(fmt.Sprintf("[getLVGThickFreeSpaces] successfully counted free VG space for LVMVolumeGroup %s", lvg.Name))
 
 		result[lvg.Name] = free.Value()
 	}
 
-	return result, nil
+	return result
 }
 
 func findMatchedThinPool(thinPools []v1alpha1.StatusThinPool, name string) *v1alpha1.StatusThinPool {
@@ -584,30 +578,17 @@ func SortLVGsByNodeName(lvgs map[string]*v1alpha1.LvmVolumeGroup) map[string][]*
 	return sorted
 }
 
-func getVGFreeSpace(lvg *v1alpha1.LvmVolumeGroup) (resource.Quantity, error) {
-	free, err := resource.ParseQuantity(lvg.Status.VGSize)
-	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("unable to parse Status.VGSize quantity for LVMVolumeGroup %s, err: %w", lvg.Name, err)
-	}
-
-	used, err := resource.ParseQuantity(lvg.Status.AllocatedSize)
-	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("unable to parse Status.AllocatedSize quantity for LVMVolumeGroup %s, err: %w", lvg.Name, err)
-	}
-
-	free.Sub(used)
-	return free, nil
+func getVGFreeSpace(lvg *v1alpha1.LvmVolumeGroup) resource.Quantity {
+	free := lvg.Status.VGSize
+	free.Sub(lvg.Status.AllocatedSize)
+	return free
 }
 
-func getThinPoolFreeSpace(tp *v1alpha1.StatusThinPool) (resource.Quantity, error) {
+func getThinPoolFreeSpace(tp *v1alpha1.StatusThinPool) resource.Quantity {
 	free := tp.ActualSize
-	used, err := resource.ParseQuantity(tp.UsedSize)
-	if err != nil {
-		return resource.Quantity{}, err
-	}
-	free.Sub(used)
+	free.Sub(tp.UsedSize)
 
-	return free, nil
+	return free
 }
 
 func getPersistentVolumes(ctx context.Context, cl client.Client) (map[string]corev1.PersistentVolume, error) {

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter.go
@@ -579,12 +579,14 @@ func SortLVGsByNodeName(lvgs map[string]*v1alpha1.LvmVolumeGroup) map[string][]*
 }
 
 func getVGFreeSpace(lvg *v1alpha1.LvmVolumeGroup) resource.Quantity {
+	// notice that .Sub method uses pointer but not a copy of the quantity
 	free := lvg.Status.VGSize
 	free.Sub(lvg.Status.AllocatedSize)
 	return free
 }
 
 func getThinPoolFreeSpace(tp *v1alpha1.StatusThinPool) resource.Quantity {
+	// notice that .Sub method uses pointer but not a copy of the quantity
 	free := tp.ActualSize
 	free.Sub(tp.UsedSize)
 

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
@@ -157,11 +157,7 @@ func scoreNodes(
 				lvg := lvgs[commonLVG.Name]
 				switch pvcReq.DeviceType {
 				case thick:
-					freeSpace, err = getVGFreeSpace(lvg)
-					if err != nil {
-						errs <- err
-						return
-					}
+					freeSpace = getVGFreeSpace(lvg)
 					log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s free thick space before PVC reservation: %s", lvg.Name, freeSpace.String()))
 					reserved, err := schedulerCache.GetLVGReservedSpace(lvg.Name)
 					if err != nil {
@@ -181,20 +177,11 @@ func scoreNodes(
 						return
 					}
 
-					freeSpace, err = getThinPoolFreeSpace(thinPool)
-					if err != nil {
-						errs <- err
-						return
-					}
+					freeSpace = getThinPoolFreeSpace(thinPool)
 				}
 
-				lvgTotalSize, err := resource.ParseQuantity(lvg.Status.VGSize)
-				if err != nil {
-					errs <- err
-					return
-				}
-				log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s total size: %s", lvg.Name, lvgTotalSize.String()))
-				totalFreeSpaceLeft += getFreeSpaceLeftPercent(freeSpace.Value(), pvcReq.RequestedSize, lvgTotalSize.Value())
+				log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s total size: %s", lvg.Name, lvg.Status.VGSize.String()))
+				totalFreeSpaceLeft += getFreeSpaceLeftPercent(freeSpace.Value(), pvcReq.RequestedSize, lvg.Status.VGSize.Value())
 			}
 
 			averageFreeSpace := totalFreeSpaceLeft / int64(len(pvcs))


### PR DESCRIPTION
## Description
Refactoring due to size field type changes from string to quantity.

## Why do we need it, and what problem does it solve?
Less parsing and more accurate code.

## What is the expected result?
No type string for any size field of any resource.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
