### PR TITLE
[controller] Add a controller to label nodes for sds-local-volume-csi

### DIFF
--- a/images/sds-local-volume-controller/api/v1alpha1/sds_local_volume_config.go
+++ b/images/sds-local-volume-controller/api/v1alpha1/sds_local_volume_config.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+type SdsLocalVolumeConfig struct {
+	NodeSelector map[string]string `yaml:"nodeSelector"`
+}

--- a/images/sds-local-volume-controller/cmd/main.go
+++ b/images/sds-local-volume-controller/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	"sds-local-volume-controller/pkg/kubutils"
 	"sds-local-volume-controller/pkg/logger"
 	"sds-local-volume-controller/pkg/monitoring"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	v1 "k8s.io/api/core/v1"
 	sv1 "k8s.io/api/storage/v1"
@@ -81,10 +82,20 @@ func main() {
 	}
 	log.Info("[main] successfully read scheme CR")
 
+	cacheOpt := cache.Options{
+		DefaultNamespaces: map[string]cache.Config{
+			cfgParams.ControllerNamespace: {},
+		},
+	}
+
 	managerOpts := manager.Options{
 		Scheme: scheme,
+		Cache:  cacheOpt,
 		//MetricsBindAddress: cfgParams.MetricsPort,
-		Logger: log.GetLogger(),
+		LeaderElection:          true,
+		LeaderElectionNamespace: cfgParams.ControllerNamespace,
+		LeaderElectionID:        config.ControllerName,
+		Logger:                  log.GetLogger(),
 	}
 
 	mgr, err := manager.New(kConfig, managerOpts)

--- a/images/sds-local-volume-controller/cmd/main.go
+++ b/images/sds-local-volume-controller/cmd/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	log.Info("[main] CfgParams has been successfully created")
 	log.Info(fmt.Sprintf("[main] %s = %s", config.LogLevel, cfgParams.Loglevel))
-	log.Info(fmt.Sprintf("[main] %s = %d", config.RequeueInterval, cfgParams.RequeueInterval))
+	log.Info(fmt.Sprintf("[main] %s = %d", config.RequeueInterval, cfgParams.RequeueStorageClassInterval))
 
 	kConfig, err := kubutils.KubernetesDefaultConfigCreate()
 	if err != nil {
@@ -97,7 +97,12 @@ func main() {
 	metrics := monitoring.GetMetrics("")
 
 	if _, err = controller.RunLocalStorageClassWatcherController(mgr, *cfgParams, *log, metrics); err != nil {
-		log.Error(err, "[main] unable to controller.RunBlockDeviceController")
+		log.Error(err, fmt.Sprintf("[main] unable to run %s", controller.LocalStorageClassCtrlName))
+		os.Exit(1)
+	}
+
+	if _, err = controller.RunLocalCSINodeWatcherController(mgr, *cfgParams, *log, metrics); err != nil {
+		log.Error(err, fmt.Sprintf("[main] unable to run %s", controller.LocalCSINodeWatcherCtrl))
 		os.Exit(1)
 	}
 

--- a/images/sds-local-volume-controller/go.mod
+++ b/images/sds-local-volume-controller/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/go-logr/logr v1.4.1
 	github.com/prometheus/client_golang v1.18.0
-	gopkg.in/yaml.v2 v2.4.0
+	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.29.1
 	k8s.io/apiextensions-apiserver v0.29.1
 	k8s.io/apimachinery v0.29.1
@@ -13,6 +13,7 @@ require (
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/controller-runtime v0.17.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -20,6 +21,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -41,6 +43,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
@@ -56,10 +59,10 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.29.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/images/sds-local-volume-controller/pkg/config/config.go
+++ b/images/sds-local-volume-controller/pkg/config/config.go
@@ -20,13 +20,16 @@ import (
 )
 
 const (
-	LogLevel        = "LOG_LEVEL"
-	RequeueInterval = "REQUEUE_INTERVAL"
+	LogLevel         = "LOG_LEVEL"
+	RequeueInterval  = "REQUEUE_INTERVAL"
+	ConfigSecretName = "d8-sds-local-volume-controller-config"
 )
 
 type Options struct {
-	Loglevel        logger.Verbosity
-	RequeueInterval time.Duration
+	Loglevel                    logger.Verbosity
+	RequeueStorageClassInterval time.Duration
+	RequeueSecretInterval       time.Duration
+	ConfigSecretName            string
 }
 
 func NewConfig() *Options {
@@ -39,7 +42,9 @@ func NewConfig() *Options {
 		opts.Loglevel = logger.Verbosity(loglevel)
 	}
 
-	opts.RequeueInterval = 10
+	opts.RequeueStorageClassInterval = 10
+	opts.RequeueSecretInterval = 10
+	opts.ConfigSecretName = ConfigSecretName
 
 	return &opts
 }

--- a/images/sds-local-volume-controller/pkg/config/config.go
+++ b/images/sds-local-volume-controller/pkg/config/config.go
@@ -14,15 +14,19 @@ limitations under the License.
 package config
 
 import (
+	"log"
 	"os"
 	"sds-local-volume-controller/pkg/logger"
 	"time"
 )
 
 const (
-	LogLevel         = "LOG_LEVEL"
-	RequeueInterval  = "REQUEUE_INTERVAL"
-	ConfigSecretName = "d8-sds-local-volume-controller-config"
+	LogLevel               = "LOG_LEVEL"
+	RequeueInterval        = "REQUEUE_INTERVAL"
+	ConfigSecretName       = "d8-sds-local-volume-controller-config"
+	ControllerNamespaceEnv = "CONTROLLER_NAMESPACE"
+	HardcodedControllerNS  = "d8-sds-local-volume"
+	ControllerName         = "sds-local-volume-controller"
 )
 
 type Options struct {
@@ -30,6 +34,7 @@ type Options struct {
 	RequeueStorageClassInterval time.Duration
 	RequeueSecretInterval       time.Duration
 	ConfigSecretName            string
+	ControllerNamespace         string
 }
 
 func NewConfig() *Options {
@@ -40,6 +45,20 @@ func NewConfig() *Options {
 		opts.Loglevel = logger.DebugLevel
 	} else {
 		opts.Loglevel = logger.Verbosity(loglevel)
+	}
+
+	opts.ControllerNamespace = os.Getenv(ControllerNamespaceEnv)
+	if opts.ControllerNamespace == "" {
+
+		namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		if err != nil {
+			log.Printf("Failed to get namespace from filesystem: %v", err)
+			log.Printf("Using hardcoded namespace: %s", HardcodedControllerNS)
+			opts.ControllerNamespace = HardcodedControllerNS
+		} else {
+			log.Printf("Got namespace from filesystem: %s", string(namespace))
+			opts.ControllerNamespace = string(namespace)
+		}
 	}
 
 	opts.RequeueStorageClassInterval = 10

--- a/images/sds-local-volume-controller/pkg/controller/local_csi_node_watcher.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_csi_node_watcher.go
@@ -173,6 +173,8 @@ func reconcileLocalCSILabels(ctx context.Context, cl client.Client, log logger.L
 			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] no dependent resources were found for the node %s. Label %s will be removed from the node", node.Name, localCsiNodeSelectorLabel))
 
 			delete(node.Labels, localCsiNodeSelectorLabel)
+			delete(node.Labels, nodeManualEvictionLabel)
+
 			err = cl.Update(ctx, &node)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the node %s", node.Name))

--- a/images/sds-local-volume-controller/pkg/controller/local_csi_node_watcher.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_csi_node_watcher.go
@@ -1,0 +1,471 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sds-local-volume-controller/api/v1alpha1"
+	"sds-local-volume-controller/pkg/config"
+	"sds-local-volume-controller/pkg/logger"
+	"sds-local-volume-controller/pkg/monitoring"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/yaml"
+	"strings"
+	"time"
+)
+
+const (
+	LocalCSINodeWatcherCtrl = "local-csi-node-watcher-controller"
+
+	localCsiNodeSelectorLabel    = "storage.deckhouse.io/sds-local-volume-node"
+	nodeManualEvictionLabel      = "storage.deckhouse.io/sds-local-volume-need-manual-eviction"
+	candidateManualEvictionLabel = "storage.deckhouse.io/sds-local-volume-candidate-for-eviction"
+)
+
+func RunLocalCSINodeWatcherController(
+	mgr manager.Manager,
+	cfg config.Options,
+	log logger.Logger,
+	metrics monitoring.Metrics,
+) (controller.Controller, error) {
+	cl := mgr.GetClient()
+
+	c, err := controller.New(LocalCSINodeWatcherCtrl, mgr, controller.Options{
+		Reconciler: reconcile.Func(func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+			log.Info(fmt.Sprintf("[RunLocalCSINodeWatcherController] Reconciler func starts a reconciliation for the request: %s", request.NamespacedName.String()))
+			if request.Name == cfg.ConfigSecretName {
+				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] request name %s matches the target config secret name %s. Start to reconcile", request.Name, cfg.ConfigSecretName))
+
+				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] tries to get a secret by the request %s", request.NamespacedName.String()))
+				secret, err := getSecret(ctx, cl, request.Namespace, request.Name)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("[RunLocalCSINodeWatcherController] unable to get a secret by the request %s", request.NamespacedName.String()))
+					return reconcile.Result{}, err
+				}
+				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] successfully got a secret by the request %s", request.NamespacedName.String()))
+
+				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] tries to reconcile local CSI nodes for the secret %s/%s", secret.Namespace, secret.Name))
+				err = reconcileLocalCSINodes(ctx, cl, log, secret)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("[RunLocalCSINodeWatcherController] unable to reconcile local CSI nodes for the secret %s/%s", secret.Namespace, secret.Name))
+					return reconcile.Result{}, err
+				}
+				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] successfully reconciled local CSI nodes for the secret %s/%s", secret.Namespace, secret.Name))
+
+				return reconcile.Result{
+					RequeueAfter: cfg.RequeueSecretInterval * time.Second,
+				}, nil
+			}
+
+			return reconcile.Result{}, nil
+		}),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.Watch(source.Kind(mgr.GetCache(), &v1.Secret{}), &handler.EnqueueRequestForObject{})
+
+	return c, err
+}
+
+func getSecret(ctx context.Context, cl client.Client, namespace, name string) (*v1.Secret, error) {
+	secret := &v1.Secret{}
+	err := cl.Get(ctx,
+		client.ObjectKey{
+			Namespace: namespace,
+			Name:      name,
+		}, secret)
+	return secret, err
+}
+
+func reconcileLocalCSINodes(ctx context.Context, cl client.Client, log logger.Logger, secret *v1.Secret) error {
+	log.Debug("[reconcileLocalCSINodes] tries to get a selector from the config")
+	nodeSelector, err := getNodeSelectorFromConfig(secret)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("[reconcileLocalCSINodes] unable to get node selector from the secret %s/%s", secret.Namespace, secret.Name))
+		return err
+	}
+	log.Trace(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] node selector from the config: %v", nodeSelector))
+	log.Debug("[reconcileLocalCSINodes] successfully got a selector from the config")
+
+	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] tries to get kubernetes nodes by the selector %v", nodeSelector))
+	nodesWithSelector, err := getKubernetesNodesBySelector(ctx, cl, nodeSelector)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("[reconcileLocalCSINodes] unable to get nodes by selector %v", nodeSelector))
+		return err
+	}
+	for _, n := range nodesWithSelector.Items {
+		log.Trace(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] node %s has been got by selector %v", n.Name, nodeSelector))
+	}
+	log.Debug("[reconcileLocalCSINodes] successfully got kubernetes nodes by the selector")
+
+	labelNodesWithLocalCSIIfNeeded(ctx, cl, log, nodesWithSelector)
+	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] finished labeling the selected nodes with a label %s", localCsiNodeSelectorLabel))
+
+	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] start to clear the nodes without the selector %v", nodeSelector))
+	log.Debug("[reconcileLocalCSINodes] tries to get all kubernetes nodes")
+	nodes, err := getKubeNodes(ctx, cl)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("[reconcileLocalCSINodes] unable to get nodes"))
+		return err
+	}
+	for _, n := range nodes.Items {
+		log.Trace(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] node %s has been got", n.Name))
+	}
+	log.Debug("[reconcileLocalCSINodes] successfully got all kubernetes nodes")
+
+	reconcileLocalCSILabels(ctx, cl, log, nodes, nodeSelector)
+	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] finished removing the label %s from the nodes without the selector %v", localCsiNodeSelectorLabel, nodeSelector))
+
+	return nil
+}
+
+func reconcileLocalCSILabels(ctx context.Context, cl client.Client, log logger.Logger, nodes *v1.NodeList, selector map[string]string) {
+	var err error
+	for _, node := range nodes.Items {
+		log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] starts the reconciliation for the node %s", node.Name))
+		if labels.Set(selector).AsSelector().Matches(labels.Set(node.Labels)) {
+			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] no need to remove a label %s from the node %s as its labels match the selector", localCsiNodeSelectorLabel, node.Name))
+
+			err = clearManualEvictionLabelsIfNeeded(ctx, cl, log, node)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to remove manual eviction labels %s, %s from the nodes, LVMVolumeGroup and LocalStorageClasses", nodeManualEvictionLabel, candidateManualEvictionLabel))
+			}
+			continue
+		}
+
+		if _, exist := node.Labels[localCsiNodeSelectorLabel]; !exist {
+			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] no need to remove a label %s from the node %s as it does not has the label", localCsiNodeSelectorLabel, node.Name))
+			continue
+		}
+
+		lvgsForManualEviction, lscsForManualEviction, err := getManuallyEvictedLVGsAndLSCs(ctx, cl, node)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to get LVMVolumeGroups for manual eviction for the node %s", node.Name))
+			continue
+		}
+
+		if len(lvgsForManualEviction) == 0 &&
+			len(lscsForManualEviction) == 0 {
+			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] no dependent resources were found for the node %s. Label %s will be removed from the node", node.Name, localCsiNodeSelectorLabel))
+
+			delete(node.Labels, localCsiNodeSelectorLabel)
+			err = cl.Update(ctx, &node)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the node %s", node.Name))
+				continue
+			}
+
+			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] the label %s has been successfully removed from the node %s", localCsiNodeSelectorLabel, node.Name))
+		} else {
+			lvgsNames := strings.Builder{}
+			for _, lvg := range lvgsForManualEviction {
+				lvgsNames.WriteString(fmt.Sprintf("%s ", lvg.Name))
+			}
+			lscNames := strings.Builder{}
+			for _, lsc := range lscsForManualEviction {
+				lscNames.WriteString(fmt.Sprintf("%s ", lsc.Name))
+			}
+			log.Warning(fmt.Sprintf("[reconcileLocalCSILabels] unable to remove label %s from the node %s due to the node's LVMVolumeGroups %s are used in LocalStorageClasses %s", localCsiNodeSelectorLabel, node.Name, lvgsNames.String(), lscNames.String()))
+
+			added, err := addLabelOnTheNodeIfNotExist(ctx, cl, node, nodeManualEvictionLabel)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the node %s", node.Name))
+				continue
+			}
+			if !added {
+				log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] label %s has been already added to the node %s", nodeManualEvictionLabel, node.Name))
+			} else {
+				log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] successfully added the label %s to the node %s", nodeManualEvictionLabel, node.Name))
+			}
+
+			for _, lvg := range lvgsForManualEviction {
+				added, err = addLabelOnTheLVGIfNotExist(ctx, cl, lvg, candidateManualEvictionLabel)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the LVMVolumeGroup %s", lvg.Name))
+					continue
+				}
+				if !added {
+					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] label %s has been already added to the LVMVolumeGroup %s", candidateManualEvictionLabel, lvg.Name))
+				} else {
+					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] successfully added the label %s to the LVMVolumeGroup %s", candidateManualEvictionLabel, lvg.Name))
+				}
+			}
+
+			for _, lsc := range lscsForManualEviction {
+				added, err = addLabelOnTheLSCIfNotExist(ctx, cl, lsc, candidateManualEvictionLabel)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the LocalStorageClass %s", lsc.Name))
+					continue
+				}
+				if !added {
+					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] label %s has been already added to the LocalStorageClass %s", candidateManualEvictionLabel, lsc.Name))
+				} else {
+					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] successfully added the label %s to the LocalStorageClass %s", candidateManualEvictionLabel, lsc.Name))
+				}
+			}
+		}
+		log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] ends the reconciliation for the node %s", node.Name))
+	}
+}
+
+func addLabelOnTheLSCIfNotExist(ctx context.Context, cl client.Client, lsc v1alpha1.LocalStorageClass, label string) (bool, error) {
+	if _, exist := lsc.Labels[label]; exist {
+		return false, nil
+	}
+
+	if lsc.Labels == nil {
+		lsc.Labels = make(map[string]string, 1)
+	}
+
+	lsc.Labels[label] = ""
+	err := cl.Update(ctx, &lsc)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func addLabelOnTheLVGIfNotExist(ctx context.Context, cl client.Client, lvg v1alpha1.LvmVolumeGroup, label string) (bool, error) {
+	if _, exist := lvg.Labels[label]; exist {
+		return false, nil
+	}
+
+	if lvg.Labels == nil {
+		lvg.Labels = make(map[string]string, 1)
+	}
+	lvg.Labels[label] = ""
+	err := cl.Update(ctx, &lvg)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func addLabelOnTheNodeIfNotExist(ctx context.Context, cl client.Client, node v1.Node, label string) (bool, error) {
+	if _, exist := node.Labels[label]; exist {
+		return false, nil
+	}
+
+	node.Labels[label] = ""
+	err := cl.Update(ctx, &node)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func clearManualEvictionLabelsIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, node v1.Node) error {
+	if _, exist := node.Labels[nodeManualEvictionLabel]; !exist {
+		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the node %s does not have the label %s", node.Name, nodeManualEvictionLabel))
+	} else {
+		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the node %s has the label %s. It will be removed", node.Name, nodeManualEvictionLabel))
+		delete(node.Labels, nodeManualEvictionLabel)
+		err := cl.Update(ctx, &node)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] unable to update the node %s", node.Name))
+			return err
+		}
+	}
+
+	lvgList, err := getLVMVolumeGroups(ctx, cl)
+	if err != nil {
+		log.Error(err, "[clearManualEvictionLabelsIfNeeded] unable to get LVMVolumeGroups")
+		return err
+	}
+
+	lvgs := make(map[string]v1alpha1.LvmVolumeGroup, len(lvgList.Items))
+	for _, lvg := range lvgList.Items {
+		lvgs[lvg.Name] = lvg
+	}
+
+	usedLvgs := make(map[string]v1alpha1.LvmVolumeGroup, len(lvgList.Items))
+	for _, lvg := range lvgList.Items {
+		for _, n := range lvg.Status.Nodes {
+			if n.Name == node.Name {
+				usedLvgs[lvg.Name] = lvg
+			}
+		}
+	}
+
+	log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] starts the removing label %s from the LVMVolumeGroups for the node %s", candidateManualEvictionLabel, node.Name))
+	for _, lvg := range usedLvgs {
+		if _, exist := lvg.Labels[candidateManualEvictionLabel]; !exist {
+			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LVMVolumeGroup %s does not has the label %s", lvg.Name, candidateManualEvictionLabel))
+			continue
+		}
+
+		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LVMVolumeGroup %s has a label %s. It will be removed", lvg.Name, candidateManualEvictionLabel))
+		delete(lvg.Labels, candidateManualEvictionLabel)
+		err = cl.Update(ctx, &lvg)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] unable to update the LVMVolumeGroup %s", lvg.Name))
+			continue
+		}
+		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LVMVolumeGroup %s label %s has been successfully removed", lvg.Name, candidateManualEvictionLabel))
+	}
+	log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] finished the removing label %s from the LVMVolumeGroups for the node %s", candidateManualEvictionLabel, node.Name))
+
+	lscList, err := getLocalStorageClasses(ctx, cl)
+	if err != nil {
+		return err
+	}
+
+	for _, lsc := range lscList.Items {
+		if _, exist := lsc.Labels[candidateManualEvictionLabel]; !exist {
+			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LocalStorageClass %s does not have the label %s", lsc.Name, candidateManualEvictionLabel))
+			continue
+		}
+
+		healthy := true
+		badLVGs := strings.Builder{}
+		for _, lvg := range lsc.Spec.LVM.LVMVolumeGroups {
+			kubeLvg := lvgs[lvg.Name]
+
+			if _, exist := kubeLvg.Labels[candidateManualEvictionLabel]; exist {
+				healthy = false
+				badLVGs.WriteString(fmt.Sprintf("%s ", lvg.Name))
+			}
+		}
+
+		if !healthy {
+			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LocalStorageClass has manually evicted LVMVolumeGroups %s. The label %s will not be removed", badLVGs.String(), candidateManualEvictionLabel))
+		} else {
+			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LocalStorageClass does not have any manually evicted LVMVolumeGroup. The label %s will be removed", candidateManualEvictionLabel))
+
+			delete(lsc.Labels, candidateManualEvictionLabel)
+			err = cl.Update(ctx, &lsc)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] unable to update the LocalStorageClass %s", lsc.Name))
+				continue
+			}
+			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] successfully removed the label %s from the LocalStorageClass %s", candidateManualEvictionLabel, lsc.Name))
+		}
+	}
+
+	return nil
+}
+
+func getManuallyEvictedLVGsAndLSCs(ctx context.Context, cl client.Client, node v1.Node) (map[string]v1alpha1.LvmVolumeGroup, map[string]v1alpha1.LocalStorageClass, error) {
+	lvgList, err := getLVMVolumeGroups(ctx, cl)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	usedLvgs := make(map[string]v1alpha1.LvmVolumeGroup, len(lvgList.Items))
+	for _, lvg := range lvgList.Items {
+		for _, n := range lvg.Status.Nodes {
+			if n.Name == node.Name {
+				usedLvgs[lvg.Name] = lvg
+			}
+		}
+	}
+
+	lscList, err := getLocalStorageClasses(ctx, cl)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	unhealthyLscs := make(map[string]v1alpha1.LocalStorageClass, len(lscList.Items))
+	unhealthyLvgs := make(map[string]v1alpha1.LvmVolumeGroup, len(usedLvgs))
+
+	// This case is a base case, when the controller did not label any resource.
+	for _, lsc := range lscList.Items {
+		for _, lvg := range lsc.Spec.LVM.LVMVolumeGroups {
+			if _, match := usedLvgs[lvg.Name]; match {
+				unhealthyLvgs[lvg.Name] = usedLvgs[lvg.Name]
+				unhealthyLscs[lsc.Name] = lsc
+			}
+		}
+	}
+
+	// This case is needed to prevent ignoring unhealthy LVMVolumeGroup resources, if LocalStorageClasses were deleted.
+	for _, lvg := range usedLvgs {
+		if _, exist := lvg.Labels[candidateManualEvictionLabel]; exist {
+			unhealthyLvgs[lvg.Name] = lvg
+		}
+	}
+
+	return unhealthyLvgs, unhealthyLscs, nil
+}
+
+func getLVMVolumeGroups(ctx context.Context, cl client.Client) (*v1alpha1.LvmVolumeGroupList, error) {
+	lvgList := &v1alpha1.LvmVolumeGroupList{}
+	err := cl.List(ctx, lvgList)
+
+	return lvgList, err
+}
+
+func getLocalStorageClasses(ctx context.Context, cl client.Client) (*v1alpha1.LocalStorageClassList, error) {
+	lscList := &v1alpha1.LocalStorageClassList{}
+	err := cl.List(ctx, lscList)
+	return lscList, err
+}
+
+func getKubeNodes(ctx context.Context, cl client.Client) (*v1.NodeList, error) {
+	nodes := &v1.NodeList{}
+	err := cl.List(ctx, nodes)
+	return nodes, err
+}
+
+func getNodeSelectorFromConfig(secret *v1.Secret) (map[string]string, error) {
+	var sdsConfig v1alpha1.SdsLocalVolumeConfig
+	err := yaml.Unmarshal(secret.Data["config"], &sdsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return sdsConfig.NodeSelector, nil
+}
+
+func getKubernetesNodesBySelector(ctx context.Context, cl client.Client, selector map[string]string) (*v1.NodeList, error) {
+	nodes := &v1.NodeList{}
+	err := cl.List(ctx, nodes, client.MatchingLabels(selector))
+	return nodes, err
+}
+
+func labelNodesWithLocalCSIIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, nodes *v1.NodeList) {
+	var err error
+	for _, node := range nodes.Items {
+		if _, exist := node.Labels[localCsiNodeSelectorLabel]; exist {
+			log.Debug(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] a node %s has already been labeled with label %s", node.Name, localCsiNodeSelectorLabel))
+			continue
+		}
+
+		node.Labels[localCsiNodeSelectorLabel] = ""
+
+		err = cl.Update(ctx, &node)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] unable to update a node %s", node.Name))
+			continue
+		}
+
+		log.Debug(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] successufully added label %s to the node %s", localCsiNodeSelectorLabel, node.Name))
+	}
+}

--- a/images/sds-local-volume-controller/pkg/controller/local_csi_node_watcher_test.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_csi_node_watcher_test.go
@@ -1,0 +1,233 @@
+package controller
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sds-local-volume-controller/api/v1alpha1"
+	"sds-local-volume-controller/pkg/logger"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestRunLocalCSINodeWatcherController(t *testing.T) {
+	cl := NewFakeClient()
+	ctx := context.Background()
+	log := logger.Logger{}
+
+	t.Run("getSecret_returns_secret", func(t *testing.T) {
+		secretName := "test-name"
+		secretNamespace := "test-ns"
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+		}
+
+		err := cl.Create(ctx, secret)
+		if err != nil {
+			t.Error(err)
+		}
+
+		actual, err := getSecret(ctx, cl, secretNamespace, secretName)
+		if assert.NoError(t, err) {
+			assert.Equal(t, secretNamespace, actual.Namespace)
+			assert.Equal(t, secretName, actual.Name)
+		}
+	})
+
+	t.Run("reconcileLocalCSINodes_returns_no_error", func(t *testing.T) {
+		secretName := "test-name1"
+		secretNamespace := "test-ns"
+		data := `nodeSelector:
+  mycustomlabel: test`
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+			Data: map[string][]byte{
+				"config": []byte(data),
+			},
+		}
+
+		err := cl.Create(ctx, secret)
+		if err != nil {
+			t.Error(err)
+		}
+
+		lvgOnNode4 := &v1alpha1.LvmVolumeGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "lvgOnNode4",
+			},
+			Status: v1alpha1.LvmVolumeGroupStatus{
+				Nodes: []v1alpha1.LvmVolumeGroupNode{
+					{
+						Name: "test-node4",
+					},
+				},
+			},
+		}
+		err = cl.Create(ctx, lvgOnNode4)
+		if err != nil {
+			t.Error(err)
+		}
+
+		lsc := &v1alpha1.LocalStorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-lsc",
+			},
+			Spec: v1alpha1.LocalStorageClassSpec{
+				LVM: &v1alpha1.LocalStorageClassLVM{
+					LVMVolumeGroups: []v1alpha1.LocalStorageClassLVG{
+						{
+							Name: "lvgOnNode4",
+						},
+					},
+				},
+			},
+		}
+		err = cl.Create(ctx, lsc)
+		if err != nil {
+			t.Error(err)
+		}
+
+		nodes := []v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node1",
+					Labels: map[string]string{
+						"mycustomlabel":         "test",
+						nodeManualEvictionLabel: "",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node2",
+					Labels: map[string]string{
+						"mycustomlabel": "test",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node3",
+					Labels: map[string]string{
+						"nothing": "forme",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node4",
+					Labels: map[string]string{
+						localCsiNodeSelectorLabel: "",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node5",
+					Labels: map[string]string{
+						localCsiNodeSelectorLabel: "",
+					},
+				},
+			},
+		}
+
+		for _, n := range nodes {
+			err = cl.Create(ctx, &n)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+
+		err = reconcileLocalCSINodes(ctx, cl, log, secret)
+		if assert.NoError(t, err) {
+			nodeList := &v1.NodeList{}
+			err = cl.List(ctx, nodeList)
+			if err != nil {
+				t.Error(err)
+			}
+
+			nodeMap := make(map[string]v1.Node, len(nodeList.Items))
+			for _, n := range nodeList.Items {
+				nodeMap[n.Name] = n
+			}
+
+			// assert that healthy node lost nodeManualEvictionLabel
+			node1 := nodeMap["test-node1"]
+			_, exist := node1.Labels[nodeManualEvictionLabel]
+			assert.False(t, exist)
+
+			// assert that nodes with a selector has localCsiNodeSelectorLabel
+			node2 := nodeMap["test-node2"]
+			_, exist = node2.Labels[nodeManualEvictionLabel]
+			assert.False(t, exist)
+			_, exist = node2.Labels[localCsiNodeSelectorLabel]
+			assert.True(t, exist)
+
+			// assert that node without selector has nothing
+			node3 := nodeMap["test-node3"]
+			_, exist = node3.Labels[nodeManualEvictionLabel]
+			assert.False(t, exist)
+			_, exist = node3.Labels[localCsiNodeSelectorLabel]
+			assert.False(t, exist)
+
+			// assert that node with lvg and lsc does not lose localCsiNodeSelectorLabel and has nodeManualEvictionLabel
+			// just like its dependent resources
+			node4 := nodeMap["test-node4"]
+			_, exist = node4.Labels[nodeManualEvictionLabel]
+			assert.True(t, exist)
+			_, exist = node4.Labels[localCsiNodeSelectorLabel]
+			assert.True(t, exist)
+
+			updateLvg := &v1alpha1.LvmVolumeGroup{}
+			err = cl.Get(ctx,
+				client.ObjectKey{
+					Name: "lvgOnNode4",
+				}, updateLvg)
+			if err != nil {
+				t.Error(err)
+			}
+			_, exist = updateLvg.Labels[candidateManualEvictionLabel]
+			assert.True(t, exist)
+
+			updatedLsc := &v1alpha1.LocalStorageClass{}
+			err = cl.Get(ctx,
+				client.ObjectKey{
+					Name: "test-lsc",
+				}, updatedLsc)
+			if err != nil {
+				t.Error(err)
+			}
+			_, exist = updateLvg.Labels[candidateManualEvictionLabel]
+			assert.True(t, exist)
+
+			// assert that node without any resources lost localCsiNodeSelectorLabel
+			node5 := nodeMap["test-node5"]
+			_, exist = node5.Labels[nodeManualEvictionLabel]
+			assert.False(t, exist)
+			_, exist = node5.Labels[localCsiNodeSelectorLabel]
+			assert.False(t, exist)
+
+		}
+	})
+
+}
+
+func NewFakeClient() client.WithWatch {
+	s := scheme.Scheme
+	_ = metav1.AddMetaToScheme(s)
+	_ = v1alpha1.AddToScheme(s)
+
+	builder := fake.NewClientBuilder().WithScheme(s)
+
+	cl := builder.Build()
+	return cl
+}

--- a/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher.go
@@ -117,7 +117,7 @@ func RunLocalStorageClassWatcherController(
 			if shouldRequeue {
 				log.Warning(fmt.Sprintf("[LocalStorageClassReconciler] Reconciler will requeue the request, name: %s", request.Name))
 				return reconcile.Result{
-					RequeueAfter: cfg.RequeueInterval * time.Second,
+					RequeueAfter: cfg.RequeueStorageClassInterval * time.Second,
 				}, nil
 			}
 
@@ -151,7 +151,7 @@ func RunLocalStorageClassWatcherController(
 						Namespace: lsc.Namespace,
 						Name:      lsc.Name,
 					},
-				}, cfg.RequeueInterval*time.Second)
+				}, cfg.RequeueStorageClassInterval*time.Second)
 				return
 			}
 
@@ -167,7 +167,7 @@ func RunLocalStorageClassWatcherController(
 						Namespace: lsc.Namespace,
 						Name:      lsc.Name,
 					},
-				}, cfg.RequeueInterval*time.Second)
+				}, cfg.RequeueStorageClassInterval*time.Second)
 			}
 			log.Info(fmt.Sprintf("[CreateFunc] ends the reconciliation for the LocalStorageClass %s", e.Object.GetName()))
 		},
@@ -202,7 +202,7 @@ func RunLocalStorageClassWatcherController(
 						Namespace: newLsc.Namespace,
 						Name:      newLsc.Name,
 					},
-				}, cfg.RequeueInterval*time.Second)
+				}, cfg.RequeueStorageClassInterval*time.Second)
 				return
 			}
 
@@ -218,7 +218,7 @@ func RunLocalStorageClassWatcherController(
 						Namespace: newLsc.Namespace,
 						Name:      newLsc.Name,
 					},
-				}, cfg.RequeueInterval*time.Second)
+				}, cfg.RequeueStorageClassInterval*time.Second)
 			}
 
 			log.Info(fmt.Sprintf("[UpdateFunc] ends the reconciliation for the LocalStorageClass %s", e.ObjectNew.GetName()))

--- a/templates/sds-local-volume-controller/rbac-for-us.yaml
+++ b/templates/sds-local-volume-controller/rbac-for-us.yaml
@@ -55,6 +55,7 @@ rules:
     resources:
       - nodes
       - persistentvolumes
+      - secrets
     verbs:
       - get
       - list

--- a/templates/sds-local-volume-controller/rbac-for-us.yaml
+++ b/templates/sds-local-volume-controller/rbac-for-us.yaml
@@ -55,7 +55,6 @@ rules:
     resources:
       - nodes
       - persistentvolumes
-      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
## Description
The controller adds a special label to nodes which local-csi-node pods will be scheduled on, based on user's preferences.

A user specifies the labels, which will be used by the controller to identify desired nodes where the local-csi-node pods should be scheduled on.
The controller uses the labels as a match-selector to select the nodes and label them with its own label, which is the 
actual trigger to place the local-csi-node pods on the nodes. 

## Why do we need it, and what problem does it solve?
Without the label, local-csi-node pods are not able to be scheduled or run.

## What is the expected result?
Local-csi-node pods are scheduled on the exact nodes with user's labels. 
If the user removes the label from the node, the corresponding local-csi-node pod got removed.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
