### PR TITLE
[controller] Add some logic refactoring and minor fixes

### DIFF
--- a/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
@@ -304,7 +304,7 @@ func TestCache_UpdateLVG(t *testing.T) {
 			Name: name,
 		},
 		Status: v1alpha1.LvmVolumeGroupStatus{
-			AllocatedSize: "1Gi",
+			AllocatedSize: resource.MustParse("1Gi"),
 		},
 	}
 	cache.AddLVG(lvg)
@@ -314,7 +314,7 @@ func TestCache_UpdateLVG(t *testing.T) {
 			Name: name,
 		},
 		Status: v1alpha1.LvmVolumeGroupStatus{
-			AllocatedSize: "2Gi",
+			AllocatedSize: resource.MustParse("2Gi"),
 		},
 	}
 
@@ -352,10 +352,10 @@ func BenchmarkCache_UpdateLVG(b *testing.B) {
 					Name: name,
 				},
 				Status: v1alpha1.LvmVolumeGroupStatus{
-					AllocatedSize: fmt.Sprintf("2%dGi", i),
+					AllocatedSize: resource.MustParse(fmt.Sprintf("2%dGi", i)),
 				},
 			}
-			b.Logf("updates the LVG with allocated size: %s", updated.Status.AllocatedSize)
+			b.Logf("updates the LVG with allocated size: %s", updated.Status.AllocatedSize.String())
 			err := cache.UpdateLVG(updated)
 			if err != nil {
 				b.Error(err)
@@ -435,7 +435,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 								Name: nodeName,
 							},
 						},
-						AllocatedSize: fmt.Sprintf("1%dGi", i),
+						AllocatedSize: resource.MustParse(fmt.Sprintf("1%dGi", i)),
 					},
 				},
 				{
@@ -448,7 +448,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 								Name: nodeName,
 							},
 						},
-						AllocatedSize: fmt.Sprintf("1%dGi", i),
+						AllocatedSize: resource.MustParse(fmt.Sprintf("1%dGi", i)),
 					},
 				},
 				{
@@ -461,7 +461,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 								Name: nodeName,
 							},
 						},
-						AllocatedSize: fmt.Sprintf("1%dGi", i),
+						AllocatedSize: resource.MustParse(fmt.Sprintf("1%dGi", i)),
 					},
 				},
 			}
@@ -505,7 +505,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 						Name: fmt.Sprintf("test-lvg-%d", i),
 					},
 					Status: v1alpha1.LvmVolumeGroupStatus{
-						AllocatedSize: fmt.Sprintf("1%dGi", i+1),
+						AllocatedSize: resource.MustParse(fmt.Sprintf("1%dGi", i+1)),
 					},
 				},
 				{
@@ -513,7 +513,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 						Name: fmt.Sprintf("test-lvg-%d", i+1),
 					},
 					Status: v1alpha1.LvmVolumeGroupStatus{
-						AllocatedSize: fmt.Sprintf("1%dGi", i+1),
+						AllocatedSize: resource.MustParse(fmt.Sprintf("1%dGi", i+1)),
 					},
 				},
 				{
@@ -521,7 +521,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 						Name: fmt.Sprintf("test-lvg-%d", i+2),
 					},
 					Status: v1alpha1.LvmVolumeGroupStatus{
-						AllocatedSize: fmt.Sprintf("1%dGi", i+1),
+						AllocatedSize: resource.MustParse(fmt.Sprintf("1%dGi", i+1)),
 					},
 				},
 			}

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
@@ -105,6 +105,13 @@ func RunLVGWatcherCacheController(
 				return
 			}
 
+			err = cache.UpdateLVG(newLvg)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to update the LVMVolumeGroup %s cache", newLvg.Name))
+				return
+			}
+			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] successfully updated the LVMVolumeGroup %s in the cache", newLvg.Name))
+
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] starts to calculate the size difference for LVMVolumeGroup %s", newLvg.Name))
 			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] old state LVMVolumeGroup %s has size %s", oldLvg.Name, oldLvg.Status.AllocatedSize.String()))
 			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] new state LVMVolumeGroup %s has size %s", newLvg.Name, newLvg.Status.AllocatedSize.String()))
@@ -114,14 +121,7 @@ func RunLVGWatcherCacheController(
 				log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] the LVMVolumeGroup %s should not be reconciled", newLvg.Name))
 				return
 			}
-
-			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] the LVMVolumeGroup %s should be reconciled by Update Func. It will be updated in the cache", newLvg.Name))
-			err = cache.UpdateLVG(newLvg)
-			if err != nil {
-				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to update the LVMVolumeGroup %s cache", newLvg.Name))
-				return
-			}
-			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] successfully updated the LVMVolumeGroup %s in the cache", newLvg.Name))
+			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] the LVMVolumeGroup %s should be reconciled by Update Func", newLvg.Name))
 
 			cachedPVCs, err := cache.GetAllPVCForLVG(newLvg.Name)
 			if err != nil {

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter.go
@@ -289,7 +289,7 @@ func filterNodes(
 
 	usedLVGs := RemoveUnusedLVGs(lvgs, scLVGs)
 	for _, lvg := range usedLVGs {
-		log.Trace(fmt.Sprintf("[filterNodes] the LVMVolumeGroup %s is actually used. VG size: %s, allocatedSize: %s", lvg.Name, lvg.Status.VGSize, lvg.Status.AllocatedSize))
+		log.Trace(fmt.Sprintf("[filterNodes] the LVMVolumeGroup %s is actually used. VG size: %s, allocatedSize: %s", lvg.Name, lvg.Status.VGSize.String(), lvg.Status.AllocatedSize.String()))
 	}
 
 	lvgsThickFree := getLVGThickFreeSpaces(log, usedLVGs)


### PR DESCRIPTION
## Description
Refactored LVMVolumeGroup's updates in the cache, tests fixes and minor logs adding.

## Why do we need it, and what problem does it solve?
Prevent several bugs, more informative logs.

## What is the expected result?
No problems with using LVMVolumeGroups which have been created after scheduler's start.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
