### PR TITLE
[controller] Add AllocationLimit feature support

### DIFF
--- a/images/sds-local-volume-controller/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-local-volume-controller/api/v1alpha1/lvm_volume_group.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 Flant JSC
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,16 +36,24 @@ type LvmVolumeGroup struct {
 	Status LvmVolumeGroupStatus `json:"status,omitempty"`
 }
 
-type SpecThinPool struct {
-	Name string            `json:"name"`
-	Size resource.Quantity `json:"size"`
+type LvmVolumeGroupSpec struct {
+	ActualVGNameOnTheNode string                       `json:"actualVGNameOnTheNode"`
+	BlockDeviceNames      []string                     `json:"blockDeviceNames"`
+	ThinPools             []LvmVolumeGroupThinPoolSpec `json:"thinPools"`
+	Type                  string                       `json:"type"`
 }
 
-type LvmVolumeGroupSpec struct {
-	ActualVGNameOnTheNode string         `json:"actualVGNameOnTheNode"`
-	BlockDeviceNames      []string       `json:"blockDeviceNames"`
-	ThinPools             []SpecThinPool `json:"thinPools"`
-	Type                  string         `json:"type"`
+type LvmVolumeGroupStatus struct {
+	AllocatedSize        resource.Quantity              `json:"allocatedSize"`
+	Nodes                []LvmVolumeGroupNode           `json:"nodes"`
+	ThinPools            []LvmVolumeGroupThinPoolStatus `json:"thinPools"`
+	VGSize               resource.Quantity              `json:"vgSize"`
+	VGUuid               string                         `json:"vgUUID"`
+	Phase                string                         `json:"phase"`
+	Conditions           []metav1.Condition             `json:"conditions"`
+	ThinPoolReady        string                         `json:"thinPoolReady"`
+	ConfigurationApplied string                         `json:"configurationApplied"`
+	VGFree               resource.Quantity              `json:"vgFree"`
 }
 
 type LvmVolumeGroupDevice struct {
@@ -58,18 +69,19 @@ type LvmVolumeGroupNode struct {
 	Name    string                 `json:"name"`
 }
 
-type StatusThinPool struct {
-	Name       string            `json:"name"`
-	ActualSize resource.Quantity `json:"actualSize"`
-	UsedSize   resource.Quantity `json:"usedSize"`
+type LvmVolumeGroupThinPoolStatus struct {
+	Name            string            `json:"name"`
+	ActualSize      resource.Quantity `json:"actualSize"`
+	UsedSize        resource.Quantity `json:"usedSize"`
+	AllocatedSize   resource.Quantity `json:"allocatedSize"`
+	AvailableSpace  resource.Quantity `json:"availableSpace"`
+	AllocationLimit string            `json:"allocationLimit"`
+	Ready           bool              `json:"ready"`
+	Message         string            `json:"message"`
 }
 
-type LvmVolumeGroupStatus struct {
-	AllocatedSize resource.Quantity    `json:"allocatedSize"`
-	Health        string               `json:"health"`
-	Message       string               `json:"message"`
-	Nodes         []LvmVolumeGroupNode `json:"nodes"`
-	ThinPools     []StatusThinPool     `json:"thinPools"`
-	VGSize        resource.Quantity    `json:"vgSize"`
-	VGUuid        string               `json:"vgUUID"`
+type LvmVolumeGroupThinPoolSpec struct {
+	Name            string            `json:"name"`
+	Size            resource.Quantity `json:"size"`
+	AllocationLimit string            `json:"allocationLimit"`
 }

--- a/images/sds-local-volume-csi/Dockerfile
+++ b/images/sds-local-volume-csi/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_ALPINE=registry.deckhouse.io/base_images/alpine:3.16.3@sha256:5548e9172c24a1b0ca9afdd2bf534e265c94b12b36b3e0c0302f5853eaf00abb
-ARG BASE_GOLANG_21_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.21.4-alpine3.18@sha256:cf84f3d6882c49ea04b6478ac514a2582c8922d7e5848b43d2918fff8329f6e6
+ARG BASE_GOLANG_ALPINE_BUILDER=registry.deckhouse.io/base_images/golang:1.21.4-alpine3.18@sha256:cf84f3d6882c49ea04b6478ac514a2582c8922d7e5848b43d2918fff8329f6e6
 
-FROM $BASE_GOLANG_21_ALPINE_BUILDER as builder
+FROM $BASE_GOLANG_ALPINE_BUILDER as builder
 
 WORKDIR /go/src
 

--- a/images/sds-local-volume-csi/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-local-volume-csi/api/v1alpha1/lvm_volume_group.go
@@ -36,16 +36,24 @@ type LvmVolumeGroup struct {
 	Status LvmVolumeGroupStatus `json:"status,omitempty"`
 }
 
-type SpecThinPool struct {
-	Name string            `json:"name"`
-	Size resource.Quantity `json:"size"`
+type LvmVolumeGroupSpec struct {
+	ActualVGNameOnTheNode string                       `json:"actualVGNameOnTheNode"`
+	BlockDeviceNames      []string                     `json:"blockDeviceNames"`
+	ThinPools             []LvmVolumeGroupThinPoolSpec `json:"thinPools"`
+	Type                  string                       `json:"type"`
 }
 
-type LvmVolumeGroupSpec struct {
-	ActualVGNameOnTheNode string         `json:"actualVGNameOnTheNode"`
-	BlockDeviceNames      []string       `json:"blockDeviceNames"`
-	ThinPools             []SpecThinPool `json:"thinPools"`
-	Type                  string         `json:"type"`
+type LvmVolumeGroupStatus struct {
+	AllocatedSize        resource.Quantity              `json:"allocatedSize"`
+	Nodes                []LvmVolumeGroupNode           `json:"nodes"`
+	ThinPools            []LvmVolumeGroupThinPoolStatus `json:"thinPools"`
+	VGSize               resource.Quantity              `json:"vgSize"`
+	VGUuid               string                         `json:"vgUUID"`
+	Phase                string                         `json:"phase"`
+	Conditions           []metav1.Condition             `json:"conditions"`
+	ThinPoolReady        string                         `json:"thinPoolReady"`
+	ConfigurationApplied string                         `json:"configurationApplied"`
+	VGFree               resource.Quantity              `json:"vgFree"`
 }
 
 type LvmVolumeGroupDevice struct {
@@ -61,18 +69,19 @@ type LvmVolumeGroupNode struct {
 	Name    string                 `json:"name"`
 }
 
-type StatusThinPool struct {
-	Name       string            `json:"name"`
-	ActualSize resource.Quantity `json:"actualSize"`
-	UsedSize   resource.Quantity `json:"usedSize"`
+type LvmVolumeGroupThinPoolStatus struct {
+	Name            string            `json:"name"`
+	ActualSize      resource.Quantity `json:"actualSize"`
+	UsedSize        resource.Quantity `json:"usedSize"`
+	AllocatedSize   resource.Quantity `json:"allocatedSize"`
+	AvailableSpace  resource.Quantity `json:"availableSpace"`
+	AllocationLimit string            `json:"allocationLimit"`
+	Ready           bool              `json:"ready"`
+	Message         string            `json:"message"`
 }
 
-type LvmVolumeGroupStatus struct {
-	AllocatedSize resource.Quantity    `json:"allocatedSize"`
-	Health        string               `json:"health"`
-	Message       string               `json:"message"`
-	Nodes         []LvmVolumeGroupNode `json:"nodes"`
-	ThinPools     []StatusThinPool     `json:"thinPools"`
-	VGSize        resource.Quantity    `json:"vgSize"`
-	VGUuid        string               `json:"vgUUID"`
+type LvmVolumeGroupThinPoolSpec struct {
+	Name            string            `json:"name"`
+	Size            resource.Quantity `json:"size"`
+	AllocationLimit string            `json:"allocationLimit"`
 }

--- a/images/sds-local-volume-csi/cmd/main.go
+++ b/images/sds-local-volume-csi/cmd/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	cfgParams, err := config.NewConfig()
 	if err != nil {
-		klog.Fatal("unable to create NewConfig")
+		klog.Fatalf("unable to create NewConfig, err: %s", err.Error())
 	}
 
 	var (

--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// TODO: сделать поддержку расчета свободного места при Immediate
 func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	d.log.Info("method CreateVolume")
 

--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+// TODO: сделать поддержку расчета свободного места при Immediate
 func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	d.log.Info("method CreateVolume")
 

--- a/images/sds-local-volume-scheduler-extender/api/v1alpha1/lvm_volume_group.go
+++ b/images/sds-local-volume-scheduler-extender/api/v1alpha1/lvm_volume_group.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 Flant JSC
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,16 +36,24 @@ type LvmVolumeGroup struct {
 	Status LvmVolumeGroupStatus `json:"status,omitempty"`
 }
 
-type SpecThinPool struct {
-	Name string            `json:"name"`
-	Size resource.Quantity `json:"size"`
+type LvmVolumeGroupSpec struct {
+	ActualVGNameOnTheNode string                       `json:"actualVGNameOnTheNode"`
+	BlockDeviceNames      []string                     `json:"blockDeviceNames"`
+	ThinPools             []LvmVolumeGroupThinPoolSpec `json:"thinPools"`
+	Type                  string                       `json:"type"`
 }
 
-type LvmVolumeGroupSpec struct {
-	ActualVGNameOnTheNode string         `json:"actualVGNameOnTheNode"`
-	BlockDeviceNames      []string       `json:"blockDeviceNames"`
-	ThinPools             []SpecThinPool `json:"thinPools"`
-	Type                  string         `json:"type"`
+type LvmVolumeGroupStatus struct {
+	AllocatedSize        resource.Quantity              `json:"allocatedSize"`
+	Nodes                []LvmVolumeGroupNode           `json:"nodes"`
+	ThinPools            []LvmVolumeGroupThinPoolStatus `json:"thinPools"`
+	VGSize               resource.Quantity              `json:"vgSize"`
+	VGUuid               string                         `json:"vgUUID"`
+	Phase                string                         `json:"phase"`
+	Conditions           []metav1.Condition             `json:"conditions"`
+	ThinPoolReady        string                         `json:"thinPoolReady"`
+	ConfigurationApplied string                         `json:"configurationApplied"`
+	VGFree               resource.Quantity              `json:"vgFree"`
 }
 
 type LvmVolumeGroupDevice struct {
@@ -58,18 +69,19 @@ type LvmVolumeGroupNode struct {
 	Name    string                 `json:"name"`
 }
 
-type StatusThinPool struct {
-	Name       string            `json:"name"`
-	ActualSize resource.Quantity `json:"actualSize"`
-	UsedSize   resource.Quantity `json:"usedSize"`
+type LvmVolumeGroupThinPoolStatus struct {
+	Name            string            `json:"name"`
+	ActualSize      resource.Quantity `json:"actualSize"`
+	UsedSize        resource.Quantity `json:"usedSize"`
+	AllocatedSize   resource.Quantity `json:"allocatedSize"`
+	AvailableSpace  resource.Quantity `json:"availableSpace"`
+	AllocationLimit string            `json:"allocationLimit"`
+	Ready           bool              `json:"ready"`
+	Message         string            `json:"message"`
 }
 
-type LvmVolumeGroupStatus struct {
-	AllocatedSize resource.Quantity    `json:"allocatedSize"`
-	Health        string               `json:"health"`
-	Message       string               `json:"message"`
-	Nodes         []LvmVolumeGroupNode `json:"nodes"`
-	ThinPools     []StatusThinPool     `json:"thinPools"`
-	VGSize        resource.Quantity    `json:"vgSize"`
-	VGUuid        string               `json:"vgUUID"`
+type LvmVolumeGroupThinPoolSpec struct {
+	Name            string            `json:"name"`
+	Size            resource.Quantity `json:"size"`
+	AllocationLimit string            `json:"allocationLimit"`
 }

--- a/images/sds-local-volume-scheduler-extender/pkg/cache/cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
 	slices2 "k8s.io/utils/strings/slices"
@@ -24,7 +25,12 @@ type Cache struct {
 }
 
 type lvgCache struct {
-	lvg  *v1alpha1.LvmVolumeGroup
+	lvg       *v1alpha1.LvmVolumeGroup
+	thickPVCs sync.Map //map[string]*pvcCache
+	thinPools sync.Map //map[string]*thinPoolCache
+}
+
+type thinPoolCache struct {
 	pvcs sync.Map //map[string]*pvcCache
 }
 
@@ -43,8 +49,9 @@ func NewCache(logger logger.Logger) *Cache {
 // AddLVG adds selected LVMVolumeGroup resource to the cache. If it is already stored, does nothing.
 func (c *Cache) AddLVG(lvg *v1alpha1.LvmVolumeGroup) {
 	_, loaded := c.lvgs.LoadOrStore(lvg.Name, &lvgCache{
-		lvg:  lvg,
-		pvcs: sync.Map{},
+		lvg:       lvg,
+		thickPVCs: sync.Map{},
+		thinPools: sync.Map{},
 	})
 	if loaded {
 		c.log.Debug(fmt.Sprintf("[AddLVG] the LVMVolumeGroup %s has been already added to the cache", lvg.Name))
@@ -129,16 +136,39 @@ func (c *Cache) GetAllLVG() map[string]*v1alpha1.LvmVolumeGroup {
 	return lvgs
 }
 
-// GetLVGReservedSpace returns a sum of reserved space by every PVC in the selected LVMVolumeGroup resource. If such LVMVolumeGroup resource is not stored, returns an error.
-func (c *Cache) GetLVGReservedSpace(lvgName string) (int64, error) {
+// GetLVGThickReservedSpace returns a sum of reserved space by every thick PVC in the selected LVMVolumeGroup resource. If such LVMVolumeGroup resource is not stored, returns an error.
+func (c *Cache) GetLVGThickReservedSpace(lvgName string) (int64, error) {
 	lvg, found := c.lvgs.Load(lvgName)
 	if !found {
-		c.log.Debug(fmt.Sprintf("[GetLVGReservedSpace] the LVMVolumeGroup %s was not found in the cache. Returns 0", lvgName))
+		c.log.Debug(fmt.Sprintf("[GetLVGThickReservedSpace] the LVMVolumeGroup %s was not found in the cache. Returns 0", lvgName))
 		return 0, nil
 	}
 
 	var space int64
-	lvg.(*lvgCache).pvcs.Range(func(pvcName, pvcCh any) bool {
+	lvg.(*lvgCache).thickPVCs.Range(func(pvcName, pvcCh any) bool {
+		space += pvcCh.(*pvcCache).pvc.Spec.Resources.Requests.Storage().Value()
+		return true
+	})
+
+	return space, nil
+}
+
+// GetLVGThinReservedSpace returns a sum of reserved space by every thin PVC in the selected LVMVolumeGroup resource. If such LVMVolumeGroup resource is not stored, returns an error.
+func (c *Cache) GetLVGThinReservedSpace(lvgName string, thinPoolName string) (int64, error) {
+	lvgCh, found := c.lvgs.Load(lvgName)
+	if !found {
+		c.log.Debug(fmt.Sprintf("[GetLVGThinReservedSpace] the LVMVolumeGroup %s was not found in the cache. Returns 0", lvgName))
+		return 0, nil
+	}
+
+	thinPool, found := lvgCh.(*lvgCache).thinPools.Load(thinPoolName)
+	if !found {
+		c.log.Debug(fmt.Sprintf("[GetLVGThinReservedSpace] the Thin pool %s of the LVMVolumeGroup %s was not found in the cache. Returns 0", lvgName, thinPoolName))
+		return 0, nil
+	}
+
+	var space int64
+	thinPool.(*thinPoolCache).pvcs.Range(func(pvcName, pvcCh any) bool {
 		space += pvcCh.(*pvcCache).pvc.Spec.Resources.Requests.Storage().Value()
 		return true
 	})
@@ -171,11 +201,11 @@ func (c *Cache) DeleteLVG(lvgName string) {
 	})
 }
 
-// AddPVC adds selected PVC to selected LVMVolumeGroup resource. If the LVMVolumeGroup resource is not stored, returns an error.
+// AddThickPVC adds selected PVC to selected LVMVolumeGroup resource. If the LVMVolumeGroup resource is not stored, returns an error.
 // If selected PVC is already stored in the cache, does nothing.
-func (c *Cache) AddPVC(lvgName string, pvc *v1.PersistentVolumeClaim) error {
+func (c *Cache) AddThickPVC(lvgName string, pvc *v1.PersistentVolumeClaim) error {
 	if pvc.Status.Phase == v1.ClaimBound {
-		c.log.Warning(fmt.Sprintf("[AddPVC] PVC %s/%s has status phase BOUND. It will not be added to the cache", pvc.Namespace, pvc.Name))
+		c.log.Warning(fmt.Sprintf("[AddThickPVC] PVC %s/%s has status phase BOUND. It will not be added to the cache", pvc.Namespace, pvc.Name))
 		return nil
 	}
 
@@ -184,59 +214,170 @@ func (c *Cache) AddPVC(lvgName string, pvc *v1.PersistentVolumeClaim) error {
 	lvgCh, found := c.lvgs.Load(lvgName)
 	if !found {
 		err := fmt.Errorf("the LVMVolumeGroup %s was not found in the cache", lvgName)
-		c.log.Error(err, fmt.Sprintf("[AddPVC] an error occured while trying to add PVC %s to the cache", pvcKey))
+		c.log.Error(err, fmt.Sprintf("[AddThickPVC] an error occured while trying to add PVC %s to the cache", pvcKey))
 		return err
 	}
 
-	// this case might be triggered if the extender recovers after fail and finds some pending pvcs with selected nodes
-	c.log.Trace(fmt.Sprintf("[AddPVC] PVC %s/%s annotations: %v", pvc.Namespace, pvc.Name, pvc.Annotations))
-	if pvc.Annotations[SelectedNodeAnnotation] != "" {
-		c.log.Debug(fmt.Sprintf("[AddPVC] PVC %s/%s has selected node anotation, selected node: %s", pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
+	// this case might be triggered if the extender recovers after fail and finds some pending thickPVCs with selected nodes
+	c.log.Trace(fmt.Sprintf("[AddThickPVC] PVC %s/%s annotations: %v", pvc.Namespace, pvc.Name, pvc.Annotations))
 
-		lvgsOnTheNode, found := c.nodeLVGs.Load(pvc.Annotations[SelectedNodeAnnotation])
-		if !found {
-			err := fmt.Errorf("no LVMVolumeGroups found for the node %s", pvc.Annotations[SelectedNodeAnnotation])
-			c.log.Error(err, fmt.Sprintf("[AddPVC] an error occured while trying to add PVC %s to the cache", pvcKey))
-			return err
-		}
-
-		if !slices2.Contains(lvgsOnTheNode.([]string), lvgName) {
-			c.log.Debug(fmt.Sprintf("[AddPVC] LVMVolumeGroup %s does not belong to PVC %s/%s selected node %s. It will be skipped", lvgName, pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
-			return nil
-		}
-
-		c.log.Debug(fmt.Sprintf("[AddPVC] LVMVolumeGroup %s belongs to PVC %s/%s selected node %s", lvgName, pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
-
-		_, found = lvgCh.(*lvgCache).pvcs.Load(pvcKey)
-		if found {
-			c.log.Warning(fmt.Sprintf("[AddPVC] PVC %s cache has been already added to the LVMVolumeGroup %s", pvcKey, lvgName))
-			return nil
-		}
+	shouldAdd, err := c.shouldAddPVC(pvc, lvgCh.(*lvgCache), pvcKey, lvgName, "")
+	if err != nil {
+		return err
 	}
 
-	c.log.Debug(fmt.Sprintf("[AddPVC] new PVC %s cache will be added to the LVMVolumeGroup %s", pvcKey, lvgName))
-	c.addNewPVC(lvgCh.(*lvgCache), pvc)
+	if !shouldAdd {
+		c.log.Debug(fmt.Sprintf("[AddThickPVC] PVC %s should not be added", pvcKey))
+		return nil
+	}
+	//if pvc.Annotations[SelectedNodeAnnotation] != "" {
+	//	c.log.Debug(fmt.Sprintf("[AddThickPVC] PVC %s/%s has selected node anotation, selected node: %s", pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
+	//
+	//	lvgsOnTheNode, found := c.nodeLVGs.Load(pvc.Annotations[SelectedNodeAnnotation])
+	//	if !found {
+	//		err := fmt.Errorf("no LVMVolumeGroups found for the node %s", pvc.Annotations[SelectedNodeAnnotation])
+	//		c.log.Error(err, fmt.Sprintf("[AddThickPVC] an error occured while trying to add PVC %s to the cache", pvcKey))
+	//		return err
+	//	}
+	//
+	//	if !slices2.Contains(lvgsOnTheNode.([]string), lvgName) {
+	//		c.log.Debug(fmt.Sprintf("[AddThickPVC] LVMVolumeGroup %s does not belong to PVC %s/%s selected node %s. It will be skipped", lvgName, pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
+	//		return nil
+	//	}
+	//
+	//	c.log.Debug(fmt.Sprintf("[AddThickPVC] LVMVolumeGroup %s belongs to PVC %s/%s selected node %s", lvgName, pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
+	//
+	//	_, found = lvgCh.(*lvgCache).thickPVCs.Load(pvcKey)
+	//	if found {
+	//		c.log.Warning(fmt.Sprintf("[AddThickPVC] PVC %s cache has been already added to the LVMVolumeGroup %s", pvcKey, lvgName))
+	//		return nil
+	//	}
+	//}
+
+	c.log.Debug(fmt.Sprintf("[AddThickPVC] new PVC %s cache will be added to the LVMVolumeGroup %s", pvcKey, lvgName))
+	c.addNewThickPVC(lvgCh.(*lvgCache), pvc)
 
 	return nil
 }
 
-func (c *Cache) addNewPVC(lvgCh *lvgCache, pvc *v1.PersistentVolumeClaim) {
-	pvcKey := configurePVCKey(pvc)
-	lvgCh.pvcs.Store(pvcKey, &pvcCache{pvc: pvc, selectedNode: pvc.Annotations[SelectedNodeAnnotation]})
+func (c *Cache) shouldAddPVC(pvc *v1.PersistentVolumeClaim, lvgCh *lvgCache, pvcKey, lvgName, thinPoolName string) (bool, error) {
+	if pvc.Annotations[SelectedNodeAnnotation] != "" {
+		c.log.Debug(fmt.Sprintf("[shouldAddPVC] PVC %s/%s has selected node anotation, selected node: %s", pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
 
+		lvgsOnTheNode, found := c.nodeLVGs.Load(pvc.Annotations[SelectedNodeAnnotation])
+		if !found {
+			err := fmt.Errorf("no LVMVolumeGroups found for the node %s", pvc.Annotations[SelectedNodeAnnotation])
+			c.log.Error(err, fmt.Sprintf("[shouldAddPVC] an error occured while trying to add PVC %s to the cache", pvcKey))
+			return false, err
+		}
+
+		if !slices2.Contains(lvgsOnTheNode.([]string), lvgName) {
+			c.log.Debug(fmt.Sprintf("[shouldAddPVC] LVMVolumeGroup %s does not belong to PVC %s/%s selected node %s. It will be skipped", lvgName, pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
+			return false, nil
+		}
+
+		c.log.Debug(fmt.Sprintf("[shouldAddPVC] LVMVolumeGroup %s belongs to PVC %s/%s selected node %s", lvgName, pvc.Namespace, pvc.Name, pvc.Annotations[SelectedNodeAnnotation]))
+
+		_, found = lvgCh.thickPVCs.Load(pvcKey)
+		if found {
+			c.log.Warning(fmt.Sprintf("[shouldAddPVC] PVC %s cache has been already added as thick to the LVMVolumeGroup %s", pvcKey, lvgName))
+			return false, nil
+		}
+
+		if thinPoolName != "" {
+			thinPoolCh, found := lvgCh.thinPools.Load(thinPoolName)
+			if !found {
+				c.log.Debug(fmt.Sprintf("[shouldAddPVC] Thin pool %s was not found in the cache, PVC %s should be added", thinPoolName, pvcKey))
+				return true, nil
+			}
+
+			if _, found = thinPoolCh.(*thinPoolCache).pvcs.Load(pvcKey); found {
+				c.log.Debug(fmt.Sprintf("[shouldAddPVC] PVC %s was found in the Thin pool %s cache. No need to add", pvcKey, thinPoolName))
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func (c *Cache) AddThinPVC(lvgName, thinPoolName string, pvc *v1.PersistentVolumeClaim) error {
+	if pvc.Status.Phase == v1.ClaimBound {
+		c.log.Warning(fmt.Sprintf("[AddThinPVC] PVC %s/%s has status phase BOUND. It will not be added to the cache", pvc.Namespace, pvc.Name))
+		return nil
+	}
+
+	pvcKey := configurePVCKey(pvc)
+
+	lvgCh, found := c.lvgs.Load(lvgName)
+	if !found {
+		err := fmt.Errorf("the LVMVolumeGroup %s was not found in the cache", lvgName)
+		c.log.Error(err, fmt.Sprintf("[AddThinPVC] an error occured while trying to add PVC %s to the cache", pvcKey))
+		return err
+	}
+
+	// this case might be triggered if the extender recovers after fail and finds some pending thickPVCs with selected nodes
+	c.log.Trace(fmt.Sprintf("[AddThinPVC] PVC %s/%s annotations: %v", pvc.Namespace, pvc.Name, pvc.Annotations))
+	shouldAdd, err := c.shouldAddPVC(pvc, lvgCh.(*lvgCache), pvcKey, lvgName, thinPoolName)
+	if err != nil {
+		return err
+	}
+
+	if !shouldAdd {
+		c.log.Debug(fmt.Sprintf("[AddThinPVC] PVC %s should not be added", pvcKey))
+		return nil
+	}
+
+	c.log.Debug(fmt.Sprintf("[AddThinPVC] new PVC %s cache will be added to the LVMVolumeGroup %s", pvcKey, lvgName))
+	c.addNewThinPVC(lvgCh.(*lvgCache), pvc, thinPoolName)
+
+	return nil
+}
+
+func (c *Cache) addNewThickPVC(lvgCh *lvgCache, pvc *v1.PersistentVolumeClaim) {
+	pvcKey := configurePVCKey(pvc)
+	lvgCh.thinPools.Store(pvcKey, &pvcCache{pvc: pvc, selectedNode: pvc.Annotations[SelectedNodeAnnotation]})
+
+	c.addLVGToPVC(lvgCh.lvg.Name, pvcKey)
+}
+
+func (c *Cache) addNewThinPVC(lvgCh *lvgCache, pvc *v1.PersistentVolumeClaim, thinPoolName string) error {
+	pvcKey := configurePVCKey(pvc)
+
+	if thinPoolName == "" {
+		err := errors.New("no thin pool specified")
+		c.log.Error(err, fmt.Sprintf("[addNewThinPVC] unable to add Thin PVC %s to the cache", pvcKey))
+		return err
+	}
+
+	thinPoolCh, found := lvgCh.thinPools.Load(thinPoolName)
+	if !found {
+		err := fmt.Errorf("thin pool %s not found", thinPoolName)
+		c.log.Error(err, fmt.Sprintf("[addNewThinPVC] unable to add Thin PVC %s to the cache", pvcKey))
+		return err
+	}
+
+	thinPoolCh.(*thinPoolCache).pvcs.Store(pvcKey, pvc)
+	c.log.Debug(fmt.Sprintf("[addNewThinPVC] THIN PVC %s was added to the cache to Thin Pool %s", pvcKey, thinPoolName))
+
+	c.addLVGToPVC(lvgCh.lvg.Name, pvcKey)
+	return nil
+}
+
+func (c *Cache) addLVGToPVC(lvgName, pvcKey string) {
 	lvgsForPVC, found := c.pvcLVGs.Load(pvcKey)
 	if !found || lvgsForPVC == nil {
 		lvgsForPVC = make([]string, 0, lvgsPerPVCCount)
 	}
 
-	c.log.Trace(fmt.Sprintf("[addNewPVC] LVMVolumeGroups from the cache for PVC %s before append: %v", pvcKey, lvgsForPVC))
-	lvgsForPVC = append(lvgsForPVC.([]string), lvgCh.lvg.Name)
-	c.log.Trace(fmt.Sprintf("[addNewPVC] LVMVolumeGroups from the cache for PVC %s after append: %v", pvcKey, lvgsForPVC))
+	c.log.Trace(fmt.Sprintf("[addLVGToPVC] LVMVolumeGroups from the cache for PVC %s before append: %v", pvcKey, lvgsForPVC))
+	lvgsForPVC = append(lvgsForPVC.([]string), lvgName)
+	c.log.Trace(fmt.Sprintf("[addLVGToPVC] LVMVolumeGroups from the cache for PVC %s after append: %v", pvcKey, lvgsForPVC))
 	c.pvcLVGs.Store(pvcKey, lvgsForPVC)
 }
 
-// UpdatePVC updates selected PVC in selected LVMVolumeGroup resource. If no such PVC is stored in the cache, adds it.
-func (c *Cache) UpdatePVC(lvgName string, pvc *v1.PersistentVolumeClaim) error {
+// UpdateThickPVC updates selected PVC in selected LVMVolumeGroup resource. If no such PVC is stored in the cache, adds it.
+func (c *Cache) UpdateThickPVC(lvgName string, pvc *v1.PersistentVolumeClaim) error {
 	pvcKey := configurePVCKey(pvc)
 
 	lvgCh, found := c.lvgs.Load(lvgName)
@@ -244,12 +385,12 @@ func (c *Cache) UpdatePVC(lvgName string, pvc *v1.PersistentVolumeClaim) error {
 		return fmt.Errorf("the LVMVolumeGroup %s was not found in the cache", lvgName)
 	}
 
-	pvcCh, found := lvgCh.(*lvgCache).pvcs.Load(pvcKey)
+	pvcCh, found := lvgCh.(*lvgCache).thickPVCs.Load(pvcKey)
 	if !found {
-		c.log.Warning(fmt.Sprintf("[UpdatePVC] PVC %s was not found in the cache for the LVMVolumeGroup %s. It will be added", pvcKey, lvgName))
-		err := c.AddPVC(lvgName, pvc)
+		c.log.Warning(fmt.Sprintf("[UpdateThickPVC] PVC %s was not found in the cache for the LVMVolumeGroup %s. It will be added", pvcKey, lvgName))
+		err := c.AddThickPVC(lvgName, pvc)
 		if err != nil {
-			c.log.Error(err, fmt.Sprintf("[UpdatePVC] an error occurred while trying to update the PVC %s", pvcKey))
+			c.log.Error(err, fmt.Sprintf("[UpdateThickPVC] an error occurred while trying to update the PVC %s", pvcKey))
 			return err
 		}
 		return nil
@@ -257,22 +398,102 @@ func (c *Cache) UpdatePVC(lvgName string, pvc *v1.PersistentVolumeClaim) error {
 
 	pvcCh.(*pvcCache).pvc = pvc
 	pvcCh.(*pvcCache).selectedNode = pvc.Annotations[SelectedNodeAnnotation]
-	c.log.Debug(fmt.Sprintf("[UpdatePVC] successfully updated PVC %s with selected node %s in the cache for LVMVolumeGroup %s", pvcKey, pvc.Annotations[SelectedNodeAnnotation], lvgName))
+	c.log.Debug(fmt.Sprintf("[UpdateThickPVC] successfully updated PVC %s with selected node %s in the cache for LVMVolumeGroup %s", pvcKey, pvc.Annotations[SelectedNodeAnnotation], lvgName))
 
 	return nil
 }
 
-// GetAllPVCForLVG returns slice of PVC belonging to selected LVMVolumeGroup resource. If such LVMVolumeGroup is not stored in the cache, returns an error.
-func (c *Cache) GetAllPVCForLVG(lvgName string) ([]*v1.PersistentVolumeClaim, error) {
+func (c *Cache) UpdateThinPVC(lvgName string, pvc *v1.PersistentVolumeClaim, thinPoolName string) error {
+	pvcKey := configurePVCKey(pvc)
+
+	lvgCh, found := c.lvgs.Load(lvgName)
+	if !found {
+		return fmt.Errorf("the LVMVolumeGroup %s was not found in the cache", lvgName)
+	}
+
+	thinPoolCh, found := lvgCh.(*lvgCache).thinPools.Load(thinPoolName)
+	if !found {
+		c.log.Debug(fmt.Sprintf("[UpdateThinPVC] Thin Pool %s was not found in the LVMVolumeGroup %s, add it.", thinPoolName, lvgName))
+		err := c.addNewThinPool(lvgCh.(*lvgCache), pvc, thinPoolName)
+		if err != nil {
+			return err
+		}
+		thinPoolCh, _ = lvgCh.(*lvgCache).thinPools.Load(thinPoolName)
+	}
+
+	pvcCh, found := thinPoolCh.(*thinPoolCache).pvcs.Load(pvcKey)
+	if !found {
+		c.log.Warning(fmt.Sprintf("[UpdateThinPVC] Thin PVC %s was not found in Thin pool %s in the cache for the LVMVolumeGroup %s. It will be added", pvcKey, thinPoolName, lvgName))
+		err := c.addNewThinPVC(lvgCh.(*lvgCache), pvc, thinPoolName)
+		if err != nil {
+			c.log.Error(err, fmt.Sprintf("[UpdateThinPVC] an error occurred while trying to update the PVC %s", pvcKey))
+			return err
+		}
+		return nil
+	}
+
+	pvcCh.(*pvcCache).pvc = pvc
+	pvcCh.(*pvcCache).selectedNode = pvc.Annotations[SelectedNodeAnnotation]
+	c.log.Debug(fmt.Sprintf("[UpdateThinPVC] successfully updated THIN PVC %s with selected node %s in the cache for LVMVolumeGroup %s", pvcKey, pvc.Annotations[SelectedNodeAnnotation], lvgName))
+
+	return nil
+}
+
+func (c *Cache) addNewThinPool(lvgCh *lvgCache, pvc *v1.PersistentVolumeClaim, thinPoolName string) error {
+	pvcKey := configurePVCKey(pvc)
+
+	if len(thinPoolName) == 0 {
+		err := errors.New("no thin pool name specified")
+		c.log.Error(err, fmt.Sprintf("[addNewThinPool] unable to add thin pool for PVC %s in the LVMVolumeGroup %s", pvc.Name, lvgCh.lvg.Name))
+		return err
+	}
+
+	_, found := lvgCh.thinPools.Load(thinPoolName)
+	if found {
+		err := fmt.Errorf("thin pool %s is already created", thinPoolName)
+		c.log.Error(err, fmt.Sprintf("[addNewThinPool] unable to add new Thin pool %s to the LVMVolumeGroup %s for PVC %s", thinPoolName, lvgCh.lvg.Name, pvcKey))
+		return err
+	}
+
+	lvgCh.thinPools.Store(thinPoolName, &thinPoolCache{})
+	return nil
+}
+
+// GetAllThickPVCForLVG returns slice of PVC belonging to selected LVMVolumeGroup resource. If such LVMVolumeGroup is not stored in the cache, returns an error.
+func (c *Cache) GetAllThickPVCForLVG(lvgName string) ([]*v1.PersistentVolumeClaim, error) {
 	lvgCh, found := c.lvgs.Load(lvgName)
 	if !found {
 		err := fmt.Errorf("cache was not found for the LVMVolumeGroup %s", lvgName)
-		c.log.Error(err, fmt.Sprintf("[GetAllPVCForLVG] an error occured while trying to get all PVC for the LVMVolumeGroup %s", lvgName))
+		c.log.Error(err, fmt.Sprintf("[GetAllThickPVCForLVG] an error occured while trying to get all PVC for the LVMVolumeGroup %s", lvgName))
 		return nil, err
 	}
 
 	result := make([]*v1.PersistentVolumeClaim, 0, pvcPerLVGCount)
-	lvgCh.(*lvgCache).pvcs.Range(func(pvcName, pvcCh any) bool {
+	lvgCh.(*lvgCache).thickPVCs.Range(func(pvcName, pvcCh any) bool {
+		result = append(result, pvcCh.(*pvcCache).pvc)
+		return true
+	})
+
+	return result, nil
+}
+
+// GetAllThinPVCForLVGThinPool returns slice of PVC belonging to selected LVMVolumeGroup resource. If such LVMVolumeGroup is not stored in the cache, returns an error.
+func (c *Cache) GetAllThinPVCForLVGThinPool(lvgName, thinPoolName string) ([]*v1.PersistentVolumeClaim, error) {
+	lvgCh, found := c.lvgs.Load(lvgName)
+	if !found {
+		err := fmt.Errorf("cache was not found for the LVMVolumeGroup %s", lvgName)
+		c.log.Error(err, fmt.Sprintf("[GetAllThinPVCForLVGThinPool] an error occured while trying to get all PVC for the LVMVolumeGroup %s", lvgName))
+		return nil, err
+	}
+
+	thinPoolCh, found := lvgCh.(*lvgCache).thinPools.Load(thinPoolName)
+	if !found || thinPoolCh == nil {
+		c.log.Debug(fmt.Sprintf("[GetAllThinPVCForLVGThinPool] no Thin pool %s in the LVMVolumeGroup %s was found. Returns nil slice", thinPoolName, lvgName))
+		return nil, nil
+	}
+
+	result := make([]*v1.PersistentVolumeClaim, 0, pvcPerLVGCount)
+	thinPoolCh.(*thinPoolCache).pvcs.Range(func(pvcName, pvcCh any) bool {
 		result = append(result, pvcCh.(*pvcCache).pvc)
 		return true
 	})
@@ -292,9 +513,9 @@ func (c *Cache) GetLVGNamesForPVC(pvc *v1.PersistentVolumeClaim) []string {
 	return lvgNames.([]string)
 }
 
-// RemoveBoundedPVCSpaceReservation removes selected bounded PVC space reservation from a target LVMVolumeGroup resource. If no such LVMVolumeGroup found or PVC
+// RemoveBoundedThickPVCSpaceReservation removes selected bounded PVC space reservation from a target LVMVolumeGroup resource. If no such LVMVolumeGroup found or PVC
 // is not in a Status Bound, returns an error.
-func (c *Cache) RemoveBoundedPVCSpaceReservation(lvgName string, pvc *v1.PersistentVolumeClaim) error {
+func (c *Cache) RemoveBoundedThickPVCSpaceReservation(lvgName string, pvc *v1.PersistentVolumeClaim) error {
 	if pvc.Status.Phase != v1.ClaimBound {
 		return fmt.Errorf("PVC %s/%s not in a Status.Phase Bound", pvc.Namespace, pvc.Name)
 	}
@@ -303,18 +524,52 @@ func (c *Cache) RemoveBoundedPVCSpaceReservation(lvgName string, pvc *v1.Persist
 	lvgCh, found := c.lvgs.Load(lvgName)
 	if !found {
 		err := fmt.Errorf("LVMVolumeGroup %s was not found in the cache", lvgName)
-		c.log.Error(err, fmt.Sprintf("[RemoveBoundedPVCSpaceReservation] an error occured while trying to remove space reservation for PVC %s in the LVMVolumeGroup %s", pvcKey, lvgName))
+		c.log.Error(err, fmt.Sprintf("[RemoveBoundedThickPVCSpaceReservation] an error occured while trying to remove space reservation for PVC %s in the LVMVolumeGroup %s", pvcKey, lvgName))
 		return err
 	}
 
-	pvcCh, found := lvgCh.(*lvgCache).pvcs.Load(pvcKey)
+	pvcCh, found := lvgCh.(*lvgCache).thickPVCs.Load(pvcKey)
 	if !found || pvcCh == nil {
 		err := fmt.Errorf("cache for PVC %s was not found", pvcKey)
-		c.log.Error(err, fmt.Sprintf("[RemoveBoundedPVCSpaceReservation] an error occured while trying to remove space reservation for PVC %s in the LVMVolumeGroup %s", pvcKey, lvgName))
+		c.log.Error(err, fmt.Sprintf("[RemoveBoundedThickPVCSpaceReservation] an error occured while trying to remove space reservation for PVC %s in the LVMVolumeGroup %s", pvcKey, lvgName))
 		return err
 	}
 
-	lvgCh.(*lvgCache).pvcs.Delete(pvcKey)
+	lvgCh.(*lvgCache).thickPVCs.Delete(pvcKey)
+	c.pvcLVGs.Delete(pvcKey)
+
+	return nil
+}
+
+// RemoveBoundedThinPVCSpaceReservation removes selected bounded PVC space reservation from a target LVMVolumeGroup resource. If no such LVMVolumeGroup found or PVC
+// is not in a Status Bound, returns an error.
+func (c *Cache) RemoveBoundedThinPVCSpaceReservation(lvgName, thinPoolName string, pvc *v1.PersistentVolumeClaim) error {
+	if pvc.Status.Phase != v1.ClaimBound {
+		return fmt.Errorf("PVC %s/%s not in a Status.Phase Bound", pvc.Namespace, pvc.Name)
+	}
+
+	pvcKey := configurePVCKey(pvc)
+	lvgCh, found := c.lvgs.Load(lvgName)
+	if !found {
+		err := fmt.Errorf("LVMVolumeGroup %s was not found in the cache", lvgName)
+		c.log.Error(err, fmt.Sprintf("[RemoveBoundedThinPVCSpaceReservation] an error occured while trying to remove space reservation for PVC %s in the LVMVolumeGroup %s", pvcKey, lvgName))
+		return err
+	}
+
+	thinPoolCh, found := lvgCh.(*lvgCache).thinPools.Load(thinPoolName)
+	if !found {
+		c.log.Warning(fmt.Sprintf("[RemoveBoundedThinPVCSpaceReservation] no Thin Pool %s was found in the cache for the LVMVolumeGroup %s", thinPoolName, lvgName))
+		return nil
+	}
+
+	pvcCh, found := thinPoolCh.(*thinPoolCache).pvcs.Load(pvcKey)
+	if !found || pvcCh == nil {
+		err := fmt.Errorf("cache for PVC %s was not found", pvcKey)
+		c.log.Error(err, fmt.Sprintf("[RemoveBoundedThinPVCSpaceReservation] an error occured while trying to remove space reservation for PVC %s in the LVMVolumeGroup %s", pvcKey, lvgName))
+		return err
+	}
+
+	thinPoolCh.(*thinPoolCache).pvcs.Delete(pvcKey)
 	c.pvcLVGs.Delete(pvcKey)
 
 	return nil
@@ -330,14 +585,14 @@ func (c *Cache) CheckIsPVCStored(pvc *v1.PersistentVolumeClaim) bool {
 	return false
 }
 
-// RemoveSpaceReservationForPVCWithSelectedNode removes space reservation for selected PVC for every LVMVolumeGroup resource, which is not bound to the PVC selected node.
-func (c *Cache) RemoveSpaceReservationForPVCWithSelectedNode(pvc *v1.PersistentVolumeClaim) error {
+// RemoveSpaceReservationForThickPVCWithSelectedNode removes space reservation for selected PVC for every LVMVolumeGroup resource, which is not bound to the PVC selected node.
+func (c *Cache) RemoveSpaceReservationForThickPVCWithSelectedNode(pvc *v1.PersistentVolumeClaim, thin bool) error {
 	pvcKey := configurePVCKey(pvc)
 	selectedLVGName := ""
 
 	lvgNamesForPVC, found := c.pvcLVGs.Load(pvcKey)
 	if !found {
-		c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] cache for PVC %s has been already removed", pvcKey))
+		c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] cache for PVC %s has been already removed", pvcKey))
 		return nil
 	}
 
@@ -345,38 +600,60 @@ func (c *Cache) RemoveSpaceReservationForPVCWithSelectedNode(pvc *v1.PersistentV
 		lvgCh, found := c.lvgs.Load(lvgName)
 		if !found || lvgCh == nil {
 			err := fmt.Errorf("no cache found for the LVMVolumeGroup %s", lvgName)
-			c.log.Error(err, fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] an error occured while trying to remove space reservation for PVC %s", pvcKey))
+			c.log.Error(err, fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] an error occured while trying to remove space reservation for PVC %s", pvcKey))
 			return err
 		}
 
-		pvcCh, found := lvgCh.(*lvgCache).pvcs.Load(pvcKey)
-		if !found {
-			c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] PVC %s space reservation in the LVMVolumeGroup %s has been already removed", pvcKey, lvgName))
-			continue
-		}
+		switch thin {
+		case true:
+			lvgCh.(*lvgCache).thinPools.Range(func(thinPoolName, thinPoolCh any) bool {
+				pvcCh, found := thinPoolCh.(*thinPoolCache).pvcs.Load(pvcKey)
+				if !found {
+					c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] PVC %s space reservation in the LVMVolumeGroup %s has been already removed", pvcKey, lvgName))
+					return true
+				}
 
-		selectedNode := pvcCh.(*pvcCache).selectedNode
-		if selectedNode == "" {
-			lvgCh.(*lvgCache).pvcs.Delete(pvcKey)
-			c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] removed space reservation for PVC %s in the LVMVolumeGroup %s due the PVC got selected to the node %s", pvcKey, lvgName, pvc.Annotations[SelectedNodeAnnotation]))
-		} else {
-			selectedLVGName = lvgName
-			c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] PVC %s got selected to the node %s. It should not be revomed from the LVMVolumeGroup %s", pvcKey, pvc.Annotations[SelectedNodeAnnotation], lvgName))
+				selectedNode := pvcCh.(*pvcCache).selectedNode
+				if selectedNode == "" {
+					thinPoolCh.(*thinPoolCache).pvcs.Delete(pvcKey)
+					c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] removed space reservation for PVC %s in the Thin pool %s of the LVMVolumeGroup %s due the PVC got selected to the node %s", pvcKey, thinPoolName.(string), lvgName, pvc.Annotations[SelectedNodeAnnotation]))
+				} else {
+					selectedLVGName = lvgName
+					c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] PVC %s got selected to the node %s. It should not be revomed from the LVMVolumeGroup %s", pvcKey, pvc.Annotations[SelectedNodeAnnotation], lvgName))
+				}
+
+				return true
+			})
+		case false:
+			pvcCh, found := lvgCh.(*lvgCache).thickPVCs.Load(pvcKey)
+			if !found {
+				c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] PVC %s space reservation in the LVMVolumeGroup %s has been already removed", pvcKey, lvgName))
+				continue
+			}
+
+			selectedNode := pvcCh.(*pvcCache).selectedNode
+			if selectedNode == "" {
+				lvgCh.(*lvgCache).thickPVCs.Delete(pvcKey)
+				c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] removed space reservation for PVC %s in the LVMVolumeGroup %s due the PVC got selected to the node %s", pvcKey, lvgName, pvc.Annotations[SelectedNodeAnnotation]))
+			} else {
+				selectedLVGName = lvgName
+				c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] PVC %s got selected to the node %s. It should not be revomed from the LVMVolumeGroup %s", pvcKey, pvc.Annotations[SelectedNodeAnnotation], lvgName))
+			}
 		}
 	}
-	c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] PVC %s space reservation has been removed from LVMVolumeGroup cache", pvcKey))
+	c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] PVC %s space reservation has been removed from LVMVolumeGroup cache", pvcKey))
 
-	c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] cache for PVC %s will be wiped from unused LVMVolumeGroups", pvcKey))
+	c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] cache for PVC %s will be wiped from unused LVMVolumeGroups", pvcKey))
 	cleared := make([]string, 0, len(lvgNamesForPVC.([]string)))
 	for _, lvgName := range lvgNamesForPVC.([]string) {
 		if lvgName == selectedLVGName {
-			c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] the LVMVolumeGroup %s will be saved for PVC %s cache as used", lvgName, pvcKey))
+			c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] the LVMVolumeGroup %s will be saved for PVC %s cache as used", lvgName, pvcKey))
 			cleared = append(cleared, lvgName)
 		} else {
-			c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] the LVMVolumeGroup %s will be removed from PVC %s cache as not used", lvgName, pvcKey))
+			c.log.Debug(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] the LVMVolumeGroup %s will be removed from PVC %s cache as not used", lvgName, pvcKey))
 		}
 	}
-	c.log.Trace(fmt.Sprintf("[RemoveSpaceReservationForPVCWithSelectedNode] cleared LVMVolumeGroups for PVC %s: %v", pvcKey, cleared))
+	c.log.Trace(fmt.Sprintf("[RemoveSpaceReservationForThickPVCWithSelectedNode] cleared LVMVolumeGroups for PVC %s: %v", pvcKey, cleared))
 	c.pvcLVGs.Store(pvcKey, cleared)
 
 	return nil
@@ -392,7 +669,11 @@ func (c *Cache) RemovePVCFromTheCache(pvc *v1.PersistentVolumeClaim) {
 			for _, lvgName := range lvgArray.([]string) {
 				lvgCh, found := c.lvgs.Load(lvgName)
 				if found {
-					lvgCh.(*lvgCache).pvcs.Delete(pvcKey.(string))
+					lvgCh.(*lvgCache).thickPVCs.Delete(pvcKey.(string))
+					lvgCh.(*lvgCache).thinPools.Range(func(tpName, tpCh any) bool {
+						tpCh.(*thinPoolCache).pvcs.Delete(pvcKey)
+						return true
+					})
 				}
 			}
 		}
@@ -440,7 +721,7 @@ func (c *Cache) PrintTheCacheLog() {
 	c.lvgs.Range(func(lvgName, lvgCh any) bool {
 		c.log.Cache(fmt.Sprintf("[%s]", lvgName))
 
-		lvgCh.(*lvgCache).pvcs.Range(func(pvcName, pvcCh any) bool {
+		lvgCh.(*lvgCache).thickPVCs.Range(func(pvcName, pvcCh any) bool {
 			c.log.Cache(fmt.Sprintf("      PVC %s, selected node: %s", pvcName, pvcCh.(*pvcCache).selectedNode))
 			return true
 		})

--- a/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
@@ -573,7 +573,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 
 			lvgMp := cache.GetAllLVG()
 			for lvgName := range lvgMp {
-				_, err := cache.GetAllThickPVCForLVG(lvgName)
+				_, err := cache.GetAllPVCForLVG(lvgName)
 				if err != nil {
 					b.Error(err)
 				}

--- a/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
@@ -80,7 +80,7 @@ func BenchmarkCache_GetLVGReservedSpace(b *testing.B) {
 	}
 
 	for _, pvc := range pvcs {
-		err := cache.AddPVC(lvg.Name, &pvc)
+		err := cache.AddThickPVC(lvg.Name, &pvc)
 		if err != nil {
 			b.Error(err)
 		}
@@ -88,7 +88,7 @@ func BenchmarkCache_GetLVGReservedSpace(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, err := cache.GetLVGReservedSpace(lvg.Name)
+			_, err := cache.GetLVGThickReservedSpace(lvg.Name)
 			if err != nil {
 				b.Error(err)
 			}
@@ -145,15 +145,15 @@ func BenchmarkCache_AddPVC(b *testing.B) {
 				},
 			}
 
-			err := cache.AddPVC(lvg1.Name, pvc)
+			err := cache.AddThickPVC(lvg1.Name, pvc)
 			if err != nil {
 				b.Error(err)
 			}
-			err = cache.AddPVC(lvg2.Name, pvc)
+			err = cache.AddThickPVC(lvg2.Name, pvc)
 			if err != nil {
 				b.Error(err)
 			}
-			err = cache.AddPVC(lvg3.Name, pvc)
+			err = cache.AddThickPVC(lvg3.Name, pvc)
 			if err != nil {
 				b.Error(err)
 			}
@@ -400,11 +400,11 @@ func BenchmarkCache_UpdatePVC(b *testing.B) {
 					},
 				},
 			}
-			err := cache.UpdatePVC(lvg.Name, pvc)
+			err := cache.UpdateThickPVC(lvg.Name, pvc)
 			if err != nil {
 				b.Error(err)
 			}
-			err = cache.UpdatePVC(lvg.Name, updatedPVC)
+			err = cache.UpdateThickPVC(lvg.Name, updatedPVC)
 			if err != nil {
 				b.Error(err)
 			}
@@ -490,7 +490,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 				}
 
 				for _, pvc := range pvcs {
-					err := cache.AddPVC(lvg.Name, pvc)
+					err := cache.AddThickPVC(lvg.Name, pvc)
 					if err != nil {
 						b.Error(err)
 					}
@@ -564,7 +564,7 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 
 				for _, pvc := range pvcs {
 					for err != nil {
-						err = cache.UpdatePVC(lvg.Name, pvc)
+						err = cache.UpdateThickPVC(lvg.Name, pvc)
 					}
 
 					cache.GetLVGNamesForPVC(pvc)
@@ -573,11 +573,11 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 
 			lvgMp := cache.GetAllLVG()
 			for lvgName := range lvgMp {
-				_, err := cache.GetAllPVCForLVG(lvgName)
+				_, err := cache.GetAllThickPVCForLVG(lvgName)
 				if err != nil {
 					b.Error(err)
 				}
-				_, err = cache.GetLVGReservedSpace(lvgName)
+				_, err = cache.GetLVGThickReservedSpace(lvgName)
 				if err != nil {
 					b.Error(err)
 				}

--- a/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/cache/cache_test.go
@@ -562,9 +562,17 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 					},
 				}
 
-				for _, pvc := range pvcs {
+				for d, pvc := range pvcs {
 					for err != nil {
 						err = cache.UpdateThickPVC(lvg.Name, pvc)
+					}
+
+					for err != nil {
+						err = cache.AddThinPVC(lvg.Name, fmt.Sprintf("test-thin-%d", d), pvc)
+					}
+
+					for err != nil {
+						err = cache.UpdateThinPVC(lvg.Name, fmt.Sprintf("test-thin-%d", d), pvc)
 					}
 
 					cache.GetLVGNamesForPVC(pvc)
@@ -578,6 +586,10 @@ func BenchmarkCache_FullLoad(b *testing.B) {
 					b.Error(err)
 				}
 				_, err = cache.GetLVGThickReservedSpace(lvgName)
+				if err != nil {
+					b.Error(err)
+				}
+				_, err = cache.GetLVGThinReservedSpace(lvgName, "test-thin")
 				if err != nil {
 					b.Error(err)
 				}

--- a/images/sds-local-volume-scheduler-extender/pkg/consts/consts.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/consts/consts.go
@@ -1,0 +1,11 @@
+package consts
+
+const (
+	SdsLocalVolumeProvisioner = "local.csi.storage.deckhouse.io"
+
+	LvmTypeParamKey         = "local.csi.storage.deckhouse.io/lvm-type"
+	LvmVolumeGroupsParamKey = "local.csi.storage.deckhouse.io/lvm-volume-groups"
+
+	Thick = "Thick"
+	Thin  = "Thin"
+)

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
@@ -71,7 +71,7 @@ func RunLVGWatcherCacheController(
 			}
 
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] starts to clear the cache for the LVMVolumeGroup %s", lvg.Name))
-			pvcs, err := cache.GetAllPVCForLVG(lvg.Name)
+			pvcs, err := cache.GetAllThickPVCForLVG(lvg.Name)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to get all PVC for the LVMVolumeGroup %s", lvg.Name))
 			}
@@ -123,7 +123,7 @@ func RunLVGWatcherCacheController(
 			}
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] the LVMVolumeGroup %s should be reconciled by Update Func", newLvg.Name))
 
-			cachedPVCs, err := cache.GetAllPVCForLVG(newLvg.Name)
+			cachedPVCs, err := cache.GetAllThickPVCForLVG(newLvg.Name)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to get all PVC for the LVMVolumeGroup %s", newLvg.Name))
 			}
@@ -132,7 +132,7 @@ func RunLVGWatcherCacheController(
 				log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s has status phase %s", pvc.Namespace, pvc.Name, pvc.Status.Phase))
 				if pvc.Status.Phase == v1.ClaimBound {
 					log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s from the cache has Status.Phase Bound. It will be removed from the reserved space in the LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
-					err = cache.RemoveBoundedPVCSpaceReservation(newLvg.Name, pvc)
+					err = cache.RemoveBoundedThickPVCSpaceReservation(newLvg.Name, pvc)
 					if err != nil {
 						log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to remove PVC %s/%s from the cache in the LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
 						continue

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
+	"reflect"
 	"sds-local-volume-scheduler-extender/api/v1alpha1"
 	"sds-local-volume-scheduler-extender/pkg/cache"
 	"sds-local-volume-scheduler-extender/pkg/logger"
@@ -71,7 +72,7 @@ func RunLVGWatcherCacheController(
 			}
 
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] starts to clear the cache for the LVMVolumeGroup %s", lvg.Name))
-			pvcs, err := cache.GetAllThickPVCForLVG(lvg.Name)
+			pvcs, err := cache.GetAllPVCForLVG(lvg.Name)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to get all PVC for the LVMVolumeGroup %s", lvg.Name))
 			}
@@ -116,27 +117,31 @@ func RunLVGWatcherCacheController(
 			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] old state LVMVolumeGroup %s has size %s", oldLvg.Name, oldLvg.Status.AllocatedSize.String()))
 			log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] new state LVMVolumeGroup %s has size %s", newLvg.Name, newLvg.Status.AllocatedSize.String()))
 
-			if newLvg.DeletionTimestamp != nil ||
-				oldLvg.Status.AllocatedSize.Value() == newLvg.Status.AllocatedSize.Value() {
+			if !shouldReconcileLVG(oldLvg, newLvg) {
 				log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] the LVMVolumeGroup %s should not be reconciled", newLvg.Name))
 				return
 			}
 			log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] the LVMVolumeGroup %s should be reconciled by Update Func", newLvg.Name))
 
-			cachedPVCs, err := cache.GetAllThickPVCForLVG(newLvg.Name)
+			cachedPVCs, err := cache.GetAllPVCForLVG(newLvg.Name)
 			if err != nil {
 				log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to get all PVC for the LVMVolumeGroup %s", newLvg.Name))
 			}
+
 			for _, pvc := range cachedPVCs {
 				log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s from the cache belongs to LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
 				log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s has status phase %s", pvc.Namespace, pvc.Name, pvc.Status.Phase))
 				if pvc.Status.Phase == v1.ClaimBound {
 					log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s from the cache has Status.Phase Bound. It will be removed from the reserved space in the LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
-					err = cache.RemoveBoundedThickPVCSpaceReservation(newLvg.Name, pvc)
-					if err != nil {
-						log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to remove PVC %s/%s from the cache in the LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
-						continue
-					}
+					//err = cache.RemoveBoundedThickPVCSpaceReservation(newLvg.Name, pvc)
+					//if err != nil {
+					//	log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to remove PVC %s/%s from the cache in the LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
+					//	continue
+					//}
+
+					cache.RemovePVCFromTheCache(pvc)
+
+					//err = cache.RemoveBoundedThinPVCSpaceReservation()
 
 					log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s was removed from the LVMVolumeGroup %s in the cache", pvc.Namespace, pvc.Name, newLvg.Name))
 				}
@@ -162,4 +167,17 @@ func RunLVGWatcherCacheController(
 	}
 
 	return c, nil
+}
+
+func shouldReconcileLVG(oldLVG, newLVG *v1alpha1.LvmVolumeGroup) bool {
+	if newLVG.DeletionTimestamp != nil {
+		return false
+	}
+
+	if oldLVG.Status.AllocatedSize.Value() == newLVG.Status.AllocatedSize.Value() &&
+		reflect.DeepEqual(oldLVG.Status.ThinPools, newLVG.Status.ThinPools) {
+		return false
+	}
+
+	return true
 }

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/lvg_watcher_cache.go
@@ -133,16 +133,7 @@ func RunLVGWatcherCacheController(
 				log.Trace(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s has status phase %s", pvc.Namespace, pvc.Name, pvc.Status.Phase))
 				if pvc.Status.Phase == v1.ClaimBound {
 					log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s from the cache has Status.Phase Bound. It will be removed from the reserved space in the LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
-					//err = cache.RemoveBoundedThickPVCSpaceReservation(newLvg.Name, pvc)
-					//if err != nil {
-					//	log.Error(err, fmt.Sprintf("[RunLVGWatcherCacheController] unable to remove PVC %s/%s from the cache in the LVMVolumeGroup %s", pvc.Namespace, pvc.Name, newLvg.Name))
-					//	continue
-					//}
-
 					cache.RemovePVCFromTheCache(pvc)
-
-					//err = cache.RemoveBoundedThinPVCSpaceReservation()
-
 					log.Debug(fmt.Sprintf("[RunLVGWatcherCacheController] PVC %s/%s was removed from the LVMVolumeGroup %s in the cache", pvc.Namespace, pvc.Name, newLvg.Name))
 				}
 			}

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/pvc_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/pvc_watcher_cache.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/strings/slices"
 	"sds-local-volume-scheduler-extender/pkg/cache"
+	"sds-local-volume-scheduler-extender/pkg/consts"
 	"sds-local-volume-scheduler-extender/pkg/logger"
 	"sds-local-volume-scheduler-extender/pkg/scheduler"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,8 +22,7 @@ import (
 )
 
 const (
-	PVCWatcherCacheCtrlName   = "pvc-watcher-cache-controller"
-	sdsLocalVolumeProvisioner = "local.csi.storage.deckhouse.io"
+	PVCWatcherCacheCtrlName = "pvc-watcher-cache-controller"
 )
 
 func RunPVCWatcherCacheController(
@@ -124,27 +124,28 @@ func reconcilePVC(ctx context.Context, mgr manager.Manager, log logger.Logger, s
 		log.Trace(fmt.Sprintf("[reconcilePVC] LVMVolumeGroup %s belongs to the node %s", lvgName, selectedNodeName))
 	}
 
+	sc := &v12.StorageClass{}
+	err := mgr.GetClient().Get(ctx, client.ObjectKey{
+		Name: *pvc.Spec.StorageClassName,
+	}, sc)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("[reconcilePVC] unable to get Storage Class %s for PVC %s/%s", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name))
+		return
+	}
+
+	if sc.Provisioner != consts.SdsLocalVolumeProvisioner {
+		log.Debug(fmt.Sprintf("[reconcilePVC] Storage Class %s for PVC %s/%s is not managed by sds-local-volume-provisioner. Ends the reconciliation", sc.Name, pvc.Namespace, pvc.Name))
+		return
+	}
+
+	lvgsFromSc, err := scheduler.ExtractLVGsFromSC(sc)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("[reconcilePVC] unable to extract LVMVolumeGroups from the Storage Class %s", sc.Name))
+	}
+
 	lvgsForPVC := schedulerCache.GetLVGNamesForPVC(pvc)
 	if lvgsForPVC == nil || len(lvgsForPVC) == 0 {
 		log.Debug(fmt.Sprintf("[reconcilePVC] no LVMVolumeGroups were found in the cache for PVC %s/%s. Use Storage Class %s instead", pvc.Namespace, pvc.Name, *pvc.Spec.StorageClassName))
-		sc := &v12.StorageClass{}
-		err := mgr.GetClient().Get(ctx, client.ObjectKey{
-			Name: *pvc.Spec.StorageClassName,
-		}, sc)
-		if err != nil {
-			log.Error(err, fmt.Sprintf("[reconcilePVC] unable to get Storage Class %s for PVC %s/%s", *pvc.Spec.StorageClassName, pvc.Namespace, pvc.Name))
-			return
-		}
-
-		if sc.Provisioner != sdsLocalVolumeProvisioner {
-			log.Debug(fmt.Sprintf("[reconcilePVC] Storage Class %s for PVC %s/%s is not managed by sds-local-volume-provisioner. Ends the reconciliation", sc.Name, pvc.Namespace, pvc.Name))
-			return
-		}
-
-		lvgsFromSc, err := scheduler.ExtractLVGsFromSC(sc)
-		if err != nil {
-			log.Error(err, fmt.Sprintf("[reconcilePVC] unable to extract LVMVolumeGroups from the Storage Class %s", sc.Name))
-		}
 
 		for _, lvg := range lvgsFromSc {
 			lvgsForPVC = append(lvgsForPVC, lvg.Name)
@@ -158,6 +159,7 @@ func reconcilePVC(ctx context.Context, mgr manager.Manager, log logger.Logger, s
 	for _, pvcLvg := range lvgsForPVC {
 		if slices.Contains(lvgsOnTheNode, pvcLvg) {
 			commonLVGName = pvcLvg
+			break
 		}
 	}
 	if commonLVGName == "" {
@@ -167,18 +169,33 @@ func reconcilePVC(ctx context.Context, mgr manager.Manager, log logger.Logger, s
 
 	log.Debug(fmt.Sprintf("[reconcilePVC] successfully found common LVMVolumeGroup %s for the selected node %s and PVC %s/%s", commonLVGName, selectedNodeName, pvc.Namespace, pvc.Name))
 	log.Debug(fmt.Sprintf("[reconcilePVC] starts to update PVC %s/%s in the cache", pvc.Namespace, pvc.Name))
-	log.Trace(fmt.Sprintf("[reconcilePVC] PVC %s/%s has status phase: %s", pvc.Namespace, pvc.Name, pvc.Status.Phase))
-	err := schedulerCache.UpdateThickPVC(commonLVGName, pvc)
-	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcilePVC] unable to update PVC %s/%s in the cache", pvc.Namespace, pvc.Name))
-		return
+
+	log.Trace(fmt.Sprintf("[reconcilePVC] %s PVC %s/%s has status phase: %s", sc.Parameters[consts.LvmTypeParamKey], pvc.Namespace, pvc.Name, pvc.Status.Phase))
+	switch sc.Parameters[consts.LvmTypeParamKey] {
+	case consts.Thick:
+		err = schedulerCache.UpdateThickPVC(commonLVGName, pvc)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("[reconcilePVC] unable to update Thick PVC %s/%s in the cache", pvc.Namespace, pvc.Name))
+			return
+		}
+	case consts.Thin:
+		for _, lvg := range lvgsFromSc {
+			if lvg.Name == commonLVGName {
+				err = schedulerCache.UpdateThinPVC(commonLVGName, pvc, lvg.Thin.PoolName)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("[reconcilePVC] unable to update Thin PVC %s/%s in the cache", pvc.Namespace, pvc.Name))
+					return
+				}
+				break
+			}
+		}
 	}
-	log.Debug(fmt.Sprintf("[reconcilePVC] successfully updated PVC %s/%s in the cache", pvc.Namespace, pvc.Name))
+	log.Debug(fmt.Sprintf("[reconcilePVC] successfully updated %s PVC %s/%s in the cache", sc.Parameters[consts.LvmTypeParamKey], pvc.Namespace, pvc.Name))
 
 	log.Cache(fmt.Sprintf("[reconcilePVC] cache state BEFORE the removal space reservation for PVC %s/%s", pvc.Namespace, pvc.Name))
 	schedulerCache.PrintTheCacheLog()
 	log.Debug(fmt.Sprintf("[reconcilePVC] starts to remove space reservation for PVC %s/%s with selected node from the cache", pvc.Namespace, pvc.Name))
-	err = schedulerCache.RemoveSpaceReservationForThickPVCWithSelectedNode(pvc, false)
+	err = schedulerCache.RemoveSpaceReservationForPVCWithSelectedNode(pvc, sc.Parameters[consts.LvmTypeParamKey])
 	if err != nil {
 		log.Error(err, fmt.Sprintf("[reconcilePVC] unable to remove PVC %s/%s space reservation in the cache", pvc.Namespace, pvc.Name))
 		return

--- a/images/sds-local-volume-scheduler-extender/pkg/controller/pvc_watcher_cache.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/controller/pvc_watcher_cache.go
@@ -168,7 +168,7 @@ func reconcilePVC(ctx context.Context, mgr manager.Manager, log logger.Logger, s
 	log.Debug(fmt.Sprintf("[reconcilePVC] successfully found common LVMVolumeGroup %s for the selected node %s and PVC %s/%s", commonLVGName, selectedNodeName, pvc.Namespace, pvc.Name))
 	log.Debug(fmt.Sprintf("[reconcilePVC] starts to update PVC %s/%s in the cache", pvc.Namespace, pvc.Name))
 	log.Trace(fmt.Sprintf("[reconcilePVC] PVC %s/%s has status phase: %s", pvc.Namespace, pvc.Name, pvc.Status.Phase))
-	err := schedulerCache.UpdatePVC(commonLVGName, pvc)
+	err := schedulerCache.UpdateThickPVC(commonLVGName, pvc)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("[reconcilePVC] unable to update PVC %s/%s in the cache", pvc.Namespace, pvc.Name))
 		return
@@ -178,7 +178,7 @@ func reconcilePVC(ctx context.Context, mgr manager.Manager, log logger.Logger, s
 	log.Cache(fmt.Sprintf("[reconcilePVC] cache state BEFORE the removal space reservation for PVC %s/%s", pvc.Namespace, pvc.Name))
 	schedulerCache.PrintTheCacheLog()
 	log.Debug(fmt.Sprintf("[reconcilePVC] starts to remove space reservation for PVC %s/%s with selected node from the cache", pvc.Namespace, pvc.Name))
-	err = schedulerCache.RemoveSpaceReservationForPVCWithSelectedNode(pvc)
+	err = schedulerCache.RemoveSpaceReservationForThickPVCWithSelectedNode(pvc, false)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("[reconcilePVC] unable to remove PVC %s/%s space reservation in the cache", pvc.Namespace, pvc.Name))
 		return

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter_test.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter_test.go
@@ -20,13 +20,13 @@ func TestFilter(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: sc1,
 				},
-				Provisioner: sdsLocalVolumeProvisioner,
+				Provisioner: SdsLocalVolumeProvisioner,
 			},
 			sc2: {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: sc2,
 				},
-				Provisioner: sdsLocalVolumeProvisioner,
+				Provisioner: SdsLocalVolumeProvisioner,
 			},
 			sc3: {
 				ObjectMeta: metav1.ObjectMeta{

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter_test.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/filter_test.go
@@ -5,6 +5,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sds-local-volume-scheduler-extender/pkg/consts"
 	"sds-local-volume-scheduler-extender/pkg/logger"
 	"testing"
 )
@@ -20,13 +21,13 @@ func TestFilter(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: sc1,
 				},
-				Provisioner: SdsLocalVolumeProvisioner,
+				Provisioner: consts.SdsLocalVolumeProvisioner,
 			},
 			sc2: {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: sc2,
 				},
-				Provisioner: SdsLocalVolumeProvisioner,
+				Provisioner: consts.SdsLocalVolumeProvisioner,
 			},
 			sc3: {
 				ObjectMeta: metav1.ObjectMeta{

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"net/http"
 	"sds-local-volume-scheduler-extender/pkg/cache"
+	"sds-local-volume-scheduler-extender/pkg/consts"
 	"sds-local-volume-scheduler-extender/pkg/logger"
 	"sync"
 
@@ -156,9 +157,9 @@ func scoreNodes(
 				var freeSpace resource.Quantity
 				lvg := lvgs[commonLVG.Name]
 				switch pvcReq.DeviceType {
-				case thick:
+				case consts.Thick:
 					freeSpace = lvg.Status.VGFree
-					log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s free thick space before PVC reservation: %s", lvg.Name, freeSpace.String()))
+					log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s free Thick space before PVC reservation: %s", lvg.Name, freeSpace.String()))
 					reserved, err := schedulerCache.GetLVGThickReservedSpace(lvg.Name)
 					if err != nil {
 						log.Error(err, fmt.Sprintf("[scoreNodes] unable to count reserved space for the LVMVolumeGroup %s", lvg.Name))
@@ -167,8 +168,8 @@ func scoreNodes(
 					log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s PVC Space reservation: %s", lvg.Name, resource.NewQuantity(reserved, resource.BinarySI)))
 					spaceWithReserved := freeSpace.Value() - reserved
 					freeSpace = *resource.NewQuantity(spaceWithReserved, resource.BinarySI)
-					log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s free thick space after PVC reservation: %s", lvg.Name, freeSpace.String()))
-				case thin:
+					log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s free Thick space after PVC reservation: %s", lvg.Name, freeSpace.String()))
+				case consts.Thin:
 					thinPool := findMatchedThinPool(lvg.Status.ThinPools, commonLVG.Thin.PoolName)
 					if thinPool == nil {
 						err = errors.New(fmt.Sprintf("unable to match Storage Class's ThinPools with the node's one, Storage Class: %s, node: %s", *pvc.Spec.StorageClassName, node.Name))

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/prioritize.go
@@ -157,9 +157,9 @@ func scoreNodes(
 				lvg := lvgs[commonLVG.Name]
 				switch pvcReq.DeviceType {
 				case thick:
-					freeSpace = getVGFreeSpace(lvg)
+					freeSpace = lvg.Status.VGFree
 					log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s free thick space before PVC reservation: %s", lvg.Name, freeSpace.String()))
-					reserved, err := schedulerCache.GetLVGReservedSpace(lvg.Name)
+					reserved, err := schedulerCache.GetLVGThickReservedSpace(lvg.Name)
 					if err != nil {
 						log.Error(err, fmt.Sprintf("[scoreNodes] unable to count reserved space for the LVMVolumeGroup %s", lvg.Name))
 						continue
@@ -177,7 +177,7 @@ func scoreNodes(
 						return
 					}
 
-					freeSpace = getThinPoolFreeSpace(thinPool)
+					freeSpace = thinPool.AvailableSpace
 				}
 
 				log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s total size: %s", lvg.Name, lvg.Status.VGSize.String()))

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/route.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/route.go
@@ -95,7 +95,7 @@ func (s *scheduler) getCache(w http.ResponseWriter, r *http.Request) {
 
 	lvgs := s.cache.GetAllLVG()
 	for _, lvg := range lvgs {
-		pvcs, err := s.cache.GetAllThickPVCForLVG(lvg.Name)
+		pvcs, err := s.cache.GetAllPVCForLVG(lvg.Name)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			s.log.Error(err, "something bad")
@@ -168,7 +168,7 @@ func (s *scheduler) getCacheStat(w http.ResponseWriter, r *http.Request) {
 	pvcTotalCount := 0
 	lvgs := s.cache.GetAllLVG()
 	for _, lvg := range lvgs {
-		pvcs, err := s.cache.GetAllThickPVCForLVG(lvg.Name)
+		pvcs, err := s.cache.GetAllPVCForLVG(lvg.Name)
 		if err != nil {
 			s.log.Error(err, "something bad")
 		}

--- a/images/sds-local-volume-scheduler-extender/pkg/scheduler/route.go
+++ b/images/sds-local-volume-scheduler-extender/pkg/scheduler/route.go
@@ -95,7 +95,7 @@ func (s *scheduler) getCache(w http.ResponseWriter, r *http.Request) {
 
 	lvgs := s.cache.GetAllLVG()
 	for _, lvg := range lvgs {
-		pvcs, err := s.cache.GetAllPVCForLVG(lvg.Name)
+		pvcs, err := s.cache.GetAllThickPVCForLVG(lvg.Name)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			s.log.Error(err, "something bad")
@@ -119,7 +119,7 @@ func (s *scheduler) getCache(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for lvgName, pvcs := range result {
-		reserved, err := s.cache.GetLVGReservedSpace(lvgName)
+		reserved, err := s.cache.GetLVGThickReservedSpace(lvgName)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, err = w.Write([]byte("unable to write the cache"))
@@ -168,7 +168,7 @@ func (s *scheduler) getCacheStat(w http.ResponseWriter, r *http.Request) {
 	pvcTotalCount := 0
 	lvgs := s.cache.GetAllLVG()
 	for _, lvg := range lvgs {
-		pvcs, err := s.cache.GetAllPVCForLVG(lvg.Name)
+		pvcs, err := s.cache.GetAllThickPVCForLVG(lvg.Name)
 		if err != nil {
 			s.log.Error(err, "something bad")
 		}


### PR DESCRIPTION
## Description
Added a support for an AllocationLimit feature. It allows users to manage LVMVolumeGroup thin-pool's available space through the AllocationLimit field, so they can easily decrease or increase the amount of thin LV using the thin-pools.
The controller will filter and score the nodes according to the AllocationLimit value.

## Why do we need it, and what problem does it solve?
It prevents unexpected and unmanageable Thin LV creations and disk space overuse.

## What is the expected result?
The controller filters and scores the nodes for Thin LVs correctly according to AllocationLimit value. 
Thin LVs with requested size more than available thin pool space, should not be created (but might become such, if a user increase the AllocationLimit value).

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
