### PR TITLE
[controller] Added contiguous to LVMLogicalVolumeStatus

### DIFF
--- a/images/sds-local-volume-csi/api/v1alpha1/lvm_logical_volume.go
+++ b/images/sds-local-volume-csi/api/v1alpha1/lvm_logical_volume.go
@@ -50,11 +50,12 @@ type LVMLogicalVolumeThinSpec struct {
 }
 
 type LVMLogicalVolumeThickSpec struct {
-	Contiguous bool `json:"contiguous"`
+	Contiguous *bool `json:"contiguous"`
 }
 
 type LVMLogicalVolumeStatus struct {
 	Phase      string            `json:"phase"`
 	Reason     string            `json:"reason"`
 	ActualSize resource.Quantity `json:"actualSize"`
+	Contiguous *bool             `json:"contiguous"`
 }

--- a/images/sds-local-volume-csi/pkg/utils/func.go
+++ b/images/sds-local-volume-csi/pkg/utils/func.go
@@ -143,7 +143,6 @@ func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logg
 				return attemptCounter, nil
 			}
 		}
-
 	}
 }
 
@@ -377,9 +376,12 @@ func GetLLVSpec(log *logger.Logger, lvName string, selectedLVG v1alpha1.LvmVolum
 		}
 		log.Info(fmt.Sprintf("[GetLLVSpec] Thin pool name: %s", lvmLogicalVolumeSpec.Thin.PoolName))
 	case internal.LVMTypeThick:
-		lvmLogicalVolumeSpec.Thick = &v1alpha1.LVMLogicalVolumeThickSpec{
-			Contiguous: contiguous,
+		if contiguous {
+			lvmLogicalVolumeSpec.Thick = &v1alpha1.LVMLogicalVolumeThickSpec{
+				Contiguous: &contiguous,
+			}
 		}
+
 		log.Info(fmt.Sprintf("[GetLLVSpec] Thick contiguous: %t", contiguous))
 	}
 


### PR DESCRIPTION
## Description
Added contiguous field to LVMLogicalVolume Status field to sync data objects between different modules.

## Why do we need it, and what problem does it solve?
Consistent data objects.

## What is the expected result?
Nothing fails, LVMLogicalVolume resources are created successfully.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
