### PR TITLE
[scheduler] New way to add scheduler-extender

### DIFF
--- a/hooks/generate_scheduler_extender_certs.py
+++ b/hooks/generate_scheduler_extender_certs.py
@@ -30,7 +30,8 @@ def main():
                 "sds-local-volume-scheduler-extender",
                 f"sds-local-volume-scheduler-extender.{common.NAMESPACE}",
                 f"sds-local-volume-scheduler-extender.{common.NAMESPACE}.svc",
-                f"sds-local-volume-scheduler-extender.{common.NAMESPACE}.svc.cluster.local"]),
+                f"%CLUSTER_DOMAIN%://sds-local-volume-scheduler-extender.{common.NAMESPACE}.svc",
+            ]),
             values_path_prefix=f"{common.MODULE_NAME}.internal.customSchedulerExtenderCert"
             ),
         cn="sds-local-volume-scheduler-extender",

--- a/hooks/generate_scheduler_extender_certs.py
+++ b/hooks/generate_scheduler_extender_certs.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from lib.hooks.internal_tls import GenerateCertificateHook, TlsSecret, default_sans
+from lib.module import values as module_values
+from deckhouse import hook
+from typing import Callable
+import common
+
+def main():
+    hook = GenerateCertificateHook(
+        TlsSecret(
+            cn="sds-local-volume-scheduler-extender",
+            name="scheduler-extender-https-certs",
+            sansGenerator=default_sans([
+                "sds-local-volume-scheduler-extender",
+                f"sds-local-volume-scheduler-extender.{common.NAMESPACE}",
+                f"sds-local-volume-scheduler-extender.{common.NAMESPACE}.svc",
+                f"sds-local-volume-scheduler-extender.{common.NAMESPACE}.svc.cluster.local"]),
+            values_path_prefix=f"{common.MODULE_NAME}.internal.customSchedulerExtenderCert"
+            ),
+        cn="sds-local-volume-scheduler-extender",
+        common_ca=True,
+        namespace=common.NAMESPACE)
+
+    hook.run()
+
+if __name__ == "__main__":
+    main()

--- a/hooks/generate_webhook_certs.py
+++ b/hooks/generate_webhook_certs.py
@@ -29,7 +29,9 @@ def main():
             sansGenerator=default_sans([
                 "webhooks",
                 f"webhooks.{common.NAMESPACE}",
-                f"webhooks.{common.NAMESPACE}.svc"]),
+                f"webhooks.{common.NAMESPACE}.svc",
+                f"%CLUSTER_DOMAIN%://webhooks.{common.NAMESPACE}.svc",
+                ]),
             values_path_prefix=f"{common.MODULE_NAME}.internal.customWebhookCert"
             ),
         cn="sds-local-volume-webhooks",

--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -280,10 +280,8 @@ func (d *Driver) ListSnapshots(_ context.Context, _ *csi.ListSnapshotsRequest) (
 }
 
 func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	// Генерация уникального traceID
 	traceID := uuid.New().String()
 
-	// Начало логирования с traceID
 	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s] method ControllerExpandVolume", traceID))
 	d.log.Trace(fmt.Sprintf("[ControllerExpandVolume][traceID:%s] ========== ControllerExpandVolume ============", traceID))
 	d.log.Trace(request.String())

--- a/images/sds-local-volume-scheduler-extender/src/cmd/cmd/root.go
+++ b/images/sds-local-volume-scheduler-extender/src/cmd/cmd/root.go
@@ -59,6 +59,8 @@ const (
 	defaultDivisor    = 1
 	defaultListenAddr = ":8000"
 	defaultCacheSize  = 10
+	defaultcertFile   = "/etc/sds-local-volume-scheduler-extender/certs/tls.crt"
+	defaultkeyFile    = "/etc/sds-local-volume-scheduler-extender/certs/tls.key"
 )
 
 type Config struct {
@@ -67,6 +69,8 @@ type Config struct {
 	LogLevel               string  `json:"log-level"`
 	CacheSize              int     `json:"cache-size"`
 	HealthProbeBindAddress string  `json:"health-probe-bind-address"`
+	CertFile               string  `json:"cert-file"`
+	KeyFile                string  `json:"key-file"`
 }
 
 var config = &Config{
@@ -74,6 +78,8 @@ var config = &Config{
 	DefaultDivisor: defaultDivisor,
 	LogLevel:       "2",
 	CacheSize:      defaultCacheSize,
+	CertFile:       defaultcertFile,
+	KeyFile:        defaultkeyFile,
 }
 
 var rootCmd = &cobra.Command{
@@ -205,7 +211,7 @@ func subMain(parentCtx context.Context) error {
 	}()
 
 	log.Info(fmt.Sprintf("[subMain] starts serving on: %s", config.ListenAddr))
-	err = serv.ListenAndServe()
+	err = serv.ListenAndServeTLS(config.CertFile, config.KeyFile)
 	if !errors.Is(err, http.ErrServerClosed) {
 		log.Error(err, "[subMain] unable to run the server")
 		return err

--- a/images/sds-local-volume-scheduler-extender/src/go.mod
+++ b/images/sds-local-volume-scheduler-extender/src/go.mod
@@ -64,6 +64,7 @@ require (
 	golang.org/x/time v0.6.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/filter.go
+++ b/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/filter.go
@@ -54,21 +54,29 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	pod := inputData.Pod
-	s.log.Debug(fmt.Sprintf("[filter] starts the filtering for Pod %s/%s", pod.Namespace, pod.Name))
-	s.log.Trace(fmt.Sprintf("[filter] Pod from the request: %+v", pod))
 
-	s.log.Debug(fmt.Sprintf("[filter] Find out if the Pod %s/%s should be processed", pod.Namespace, pod.Name))
-	shouldProcess, err := ShouldProcessPod(s.ctx, s.client, s.log, pod, consts.SdsLocalVolumeProvisioner)
+	nodeNames, err := getNodeNames(inputData)
+	if err != nil {
+		s.log.Error(err, "[filter] unable to get node names from the request")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	s.log.Debug(fmt.Sprintf("[filter] starts the filtering for Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
+	s.log.Trace(fmt.Sprintf("[filter] Pod from the request: %+v", inputData.Pod))
+	s.log.Trace(fmt.Sprintf("[filter] Node names from the request: %+v", nodeNames))
+
+	s.log.Debug(fmt.Sprintf("[filter] Find out if the Pod %s/%s should be processed", inputData.Pod.Namespace, inputData.Pod.Name))
+	shouldProcess, err := shouldProcessPod(s.ctx, s.client, s.log, inputData.Pod, consts.SdsLocalVolumeProvisioner)
 	if err != nil {
 		s.log.Error(err, "[filter] unable to check if the Pod should be processed")
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 	if !shouldProcess {
-		s.log.Debug(fmt.Sprintf("[filter] Pod %s/%s should not be processed. Return the same nodes", pod.Namespace, pod.Name))
+		s.log.Debug(fmt.Sprintf("[filter] Pod %s/%s should not be processed. Return the same nodes", inputData.Pod.Namespace, inputData.Pod.Name))
 		filteredNodes := &ExtenderFilterResult{
-			NodeNames: inputData.NodeNames,
+			NodeNames: &nodeNames,
 		}
 		s.log.Trace(fmt.Sprintf("[filter] filtered nodes: %+v", filteredNodes))
 
@@ -81,32 +89,22 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] Pod %s/%s should be processed", pod.Namespace, pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] Pod %s/%s should be processed", inputData.Pod.Namespace, inputData.Pod.Name))
 
-	if inputData.NodeNames == nil || len(*inputData.NodeNames) == 0 {
-		s.log.Error(errors.New("no node names in the request"), "[filter] unable to get node names from the request")
-		http.Error(w, "bad request", http.StatusBadRequest)
-		return
-	}
-	nodeNames := inputData.NodeNames
-	for _, nodeName := range *nodeNames {
-		s.log.Debug(fmt.Sprintf("[filter] Pod %s/%s has node %s from the request", pod.Namespace, pod.Name, nodeName))
-	}
-
-	pvcs, err := getUsedPVC(s.ctx, s.client, s.log, pod)
+	pvcs, err := getUsedPVC(s.ctx, s.client, s.log, inputData.Pod)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[filter] unable to get used PVC for a Pod %s in the namespace %s", pod.Name, pod.Namespace))
+		s.log.Error(err, fmt.Sprintf("[filter] unable to get used PVC for a Pod %s in the namespace %s", inputData.Pod.Name, inputData.Pod.Namespace))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	if len(pvcs) == 0 {
-		s.log.Error(fmt.Errorf("no PVC was found for pod %s in namespace %s", pod.Name, pod.Namespace), fmt.Sprintf("[filter] unable to get used PVC for Pod %s", pod.Name))
+		s.log.Error(fmt.Errorf("no PVC was found for pod %s in namespace %s", inputData.Pod.Name, inputData.Pod.Namespace), fmt.Sprintf("[filter] unable to get used PVC for Pod %s", inputData.Pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 
 	for _, pvc := range pvcs {
-		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses PVC: %s", pod.Namespace, pod.Name, pvc.Name))
+		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses PVC: %s", inputData.Pod.Namespace, inputData.Pod.Name, pvc.Name))
 
 		// this might happen when the extender-scheduler recovers after failure, populates the cache with PVC-watcher controller and then
 		// the kube scheduler post a request to schedule the pod with the PVC.
@@ -125,7 +123,7 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, sc := range scs {
-		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses StorageClass: %s", pod.Namespace, pod.Name, sc.Name))
+		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses StorageClass: %s", inputData.Pod.Namespace, inputData.Pod.Name, sc.Name))
 	}
 
 	managedPVCs := filterNotManagedPVC(s.log, pvcs, scs)
@@ -134,39 +132,39 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(managedPVCs) == 0 {
-		s.log.Warning(fmt.Sprintf("[filter] Pod %s/%s uses PVCs which are not managed by the module. Unable to filter and score the nodes", pod.Namespace, pod.Name))
+		s.log.Warning(fmt.Sprintf("[filter] Pod %s/%s uses PVCs which are not managed by the module. Unable to filter and score the nodes", inputData.Pod.Namespace, inputData.Pod.Name))
 		return
 	}
 
-	s.log.Debug(fmt.Sprintf("[filter] starts to extract PVC requested sizes for a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] starts to extract PVC requested sizes for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
 	pvcRequests, err := extractRequestedSize(s.ctx, s.client, s.log, managedPVCs, scs)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[filter] unable to extract request size for a Pod %s/%s", pod.Namespace, pod.Name))
+		s.log.Error(err, fmt.Sprintf("[filter] unable to extract request size for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] successfully extracted the PVC requested sizes of a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] successfully extracted the PVC requested sizes of a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
 
-	s.log.Debug(fmt.Sprintf("[filter] starts to filter the nodes from the request for a Pod %s/%s", pod.Namespace, pod.Name))
-	filteredNodes, err := filterNodes(s.log, s.cache, nodeNames, pod, managedPVCs, scs, pvcRequests)
+	s.log.Debug(fmt.Sprintf("[filter] starts to filter the nodes from the request for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
+	filteredNodes, err := filterNodes(s.log, s.cache, &nodeNames, inputData.Pod, managedPVCs, scs, pvcRequests)
 	if err != nil {
 		s.log.Error(err, "[filter] unable to filter the nodes")
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] successfully filtered the nodes from the request for a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] successfully filtered the nodes from the request for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
 
-	s.log.Debug(fmt.Sprintf("[filter] starts to populate the cache for a Pod %s/%s", pod.Namespace, pod.Name))
-	s.log.Cache(fmt.Sprintf("[filter] cache before the PVC reservation for a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] starts to populate the cache for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
+	s.log.Cache(fmt.Sprintf("[filter] cache before the PVC reservation for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
 	s.cache.PrintTheCacheLog()
-	err = populateCache(s.log, filteredNodes.NodeNames, pod, s.cache, managedPVCs, scs)
+	err = populateCache(s.log, filteredNodes.NodeNames, inputData.Pod, s.cache, managedPVCs, scs)
 	if err != nil {
 		s.log.Error(err, "[filter] unable to populate cache")
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] successfully populated the cache for a Pod %s/%s", pod.Namespace, pod.Name))
-	s.log.Cache(fmt.Sprintf("[filter] cache after the PVC reservation for a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] successfully populated the cache for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
+	s.log.Cache(fmt.Sprintf("[filter] cache after the PVC reservation for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
 	s.cache.PrintTheCacheLog()
 
 	w.Header().Set("content-type", "application/json")
@@ -176,7 +174,7 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] ends the serving the request for a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] ends the serving the request for a Pod %s/%s", inputData.Pod.Namespace, inputData.Pod.Name))
 }
 
 func filterNotManagedPVC(log logger.Logger, pvcs map[string]*corev1.PersistentVolumeClaim, scs map[string]*v1.StorageClass) map[string]*corev1.PersistentVolumeClaim {

--- a/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/filter.go
+++ b/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/filter.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -38,35 +39,51 @@ import (
 
 func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	s.log.Debug("[filter] starts the serving")
-	var input ExtenderArgs
+	var inputData ExtenderArgs
 	reader := http.MaxBytesReader(w, r.Body, 10<<20)
-	err := json.NewDecoder(reader).Decode(&input)
-	if err != nil || input.Nodes == nil || input.Pod == nil {
+	err := json.NewDecoder(reader).Decode(&inputData)
+	if err != nil {
 		s.log.Error(err, "[filter] unable to decode a request")
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
+	s.log.Trace(fmt.Sprintf("[filter] input data: %+v", inputData))
 
-	s.log.Debug(fmt.Sprintf("[filter] starts the filtering for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	if inputData.NodeNames == nil || len(*inputData.NodeNames) == 0 {
+		s.log.Error(errors.New("no node names in the request"), "[filter] unable to get node names from the request")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	nodeNames := inputData.NodeNames
+	s.log.Trace(fmt.Sprintf("[filter] node names from the request: %v", nodeNames))
 
-	for _, n := range input.Nodes.Items {
-		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s has node %s from the request", input.Pod.Namespace, input.Pod.Name, n.Name))
+	if inputData.Pod == nil {
+		s.log.Error(errors.New("no pod in the request"), "[filter] unable to get a Pod from the request")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	pod := inputData.Pod
+	s.log.Debug(fmt.Sprintf("[filter] starts the filtering for Pod %s/%s", pod.Namespace, pod.Name))
+
+	s.log.Trace(fmt.Sprintf("[filter] Pod from the request: %+v", pod))
+	for _, nodeName := range *nodeNames {
+		s.log.Debug(fmt.Sprintf("[filter] Pod %s/%s has node %s from the request", pod.Namespace, pod.Name, nodeName))
 	}
 
-	pvcs, err := getUsedPVC(s.ctx, s.client, s.log, input.Pod)
+	pvcs, err := getUsedPVC(s.ctx, s.client, s.log, pod)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[filter] unable to get used PVC for a Pod %s in the namespace %s", input.Pod.Name, input.Pod.Namespace))
+		s.log.Error(err, fmt.Sprintf("[filter] unable to get used PVC for a Pod %s in the namespace %s", pod.Name, pod.Namespace))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	if len(pvcs) == 0 {
-		s.log.Error(fmt.Errorf("no PVC was found for pod %s in namespace %s", input.Pod.Name, input.Pod.Namespace), fmt.Sprintf("[filter] unable to get used PVC for Pod %s", input.Pod.Name))
+		s.log.Error(fmt.Errorf("no PVC was found for pod %s in namespace %s", pod.Name, pod.Namespace), fmt.Sprintf("[filter] unable to get used PVC for Pod %s", pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 
 	for _, pvc := range pvcs {
-		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses PVC: %s", input.Pod.Namespace, input.Pod.Name, pvc.Name))
+		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses PVC: %s", pod.Namespace, pod.Name, pvc.Name))
 
 		// this might happen when the extender-scheduler recovers after failure, populates the cache with PVC-watcher controller and then
 		// the kube scheduler post a request to schedule the pod with the PVC.
@@ -85,7 +102,7 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, sc := range scs {
-		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses StorageClass: %s", input.Pod.Namespace, input.Pod.Name, sc.Name))
+		s.log.Trace(fmt.Sprintf("[filter] Pod %s/%s uses StorageClass: %s", pod.Namespace, pod.Name, sc.Name))
 	}
 
 	managedPVCs := filterNotManagedPVC(s.log, pvcs, scs)
@@ -94,39 +111,39 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(managedPVCs) == 0 {
-		s.log.Warning(fmt.Sprintf("[filter] Pod %s/%s uses PVCs which are not managed by the module. Unable to filter and score the nodes", input.Pod.Namespace, input.Pod.Name))
+		s.log.Warning(fmt.Sprintf("[filter] Pod %s/%s uses PVCs which are not managed by the module. Unable to filter and score the nodes", pod.Namespace, pod.Name))
 		return
 	}
 
-	s.log.Debug(fmt.Sprintf("[filter] starts to extract PVC requested sizes for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] starts to extract PVC requested sizes for a Pod %s/%s", pod.Namespace, pod.Name))
 	pvcRequests, err := extractRequestedSize(s.ctx, s.client, s.log, managedPVCs, scs)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[filter] unable to extract request size for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+		s.log.Error(err, fmt.Sprintf("[filter] unable to extract request size for a Pod %s/%s", pod.Namespace, pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] successfully extracted the PVC requested sizes of a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] successfully extracted the PVC requested sizes of a Pod %s/%s", pod.Namespace, pod.Name))
 
-	s.log.Debug(fmt.Sprintf("[filter] starts to filter the nodes from the request for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
-	filteredNodes, err := filterNodes(s.log, s.cache, input.Nodes, input.Pod, managedPVCs, scs, pvcRequests)
+	s.log.Debug(fmt.Sprintf("[filter] starts to filter the nodes from the request for a Pod %s/%s", pod.Namespace, pod.Name))
+	filteredNodes, err := filterNodes(s.log, s.cache, nodeNames, pod, managedPVCs, scs, pvcRequests)
 	if err != nil {
 		s.log.Error(err, "[filter] unable to filter the nodes")
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] successfully filtered the nodes from the request for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] successfully filtered the nodes from the request for a Pod %s/%s", pod.Namespace, pod.Name))
 
-	s.log.Debug(fmt.Sprintf("[filter] starts to populate the cache for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
-	s.log.Cache(fmt.Sprintf("[filter] cache before the PVC reservation for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] starts to populate the cache for a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Cache(fmt.Sprintf("[filter] cache before the PVC reservation for a Pod %s/%s", pod.Namespace, pod.Name))
 	s.cache.PrintTheCacheLog()
-	err = populateCache(s.log, filteredNodes.Nodes.Items, input.Pod, s.cache, managedPVCs, scs)
+	err = populateCache(s.log, filteredNodes.NodeNames, pod, s.cache, managedPVCs, scs)
 	if err != nil {
 		s.log.Error(err, "[filter] unable to populate cache")
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] successfully populated the cache for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
-	s.log.Cache(fmt.Sprintf("[filter] cache after the PVC reservation for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] successfully populated the cache for a Pod %s/%s", pod.Namespace, pod.Name))
+	s.log.Cache(fmt.Sprintf("[filter] cache after the PVC reservation for a Pod %s/%s", pod.Namespace, pod.Name))
 	s.cache.PrintTheCacheLog()
 
 	w.Header().Set("content-type", "application/json")
@@ -136,7 +153,7 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[filter] ends the serving the request for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[filter] ends the serving the request for a Pod %s/%s", pod.Namespace, pod.Name))
 }
 
 func filterNotManagedPVC(log logger.Logger, pvcs map[string]*corev1.PersistentVolumeClaim, scs map[string]*v1.StorageClass) map[string]*corev1.PersistentVolumeClaim {
@@ -154,13 +171,13 @@ func filterNotManagedPVC(log logger.Logger, pvcs map[string]*corev1.PersistentVo
 	return filteredPVCs
 }
 
-func populateCache(log logger.Logger, nodes []corev1.Node, pod *corev1.Pod, schedulerCache *cache.Cache, pvcs map[string]*corev1.PersistentVolumeClaim, scs map[string]*v1.StorageClass) error {
-	for _, node := range nodes {
+func populateCache(log logger.Logger, nodeNames *[]string, pod *corev1.Pod, schedulerCache *cache.Cache, pvcs map[string]*corev1.PersistentVolumeClaim, scs map[string]*v1.StorageClass) error {
+	for _, nodeName := range *nodeNames {
 		for _, volume := range pod.Spec.Volumes {
 			if volume.PersistentVolumeClaim != nil {
-				log.Debug(fmt.Sprintf("[populateCache] reconcile the PVC %s for Pod %s/%s on node %s", volume.PersistentVolumeClaim.ClaimName, pod.Namespace, pod.Name, node.Name))
-				lvgNamesForTheNode := schedulerCache.GetLVGNamesByNodeName(node.Name)
-				log.Trace(fmt.Sprintf("[populateCache] LVMVolumeGroups from cache for the node %s: %v", node.Name, lvgNamesForTheNode))
+				log.Debug(fmt.Sprintf("[populateCache] reconcile the PVC %s for Pod %s/%s on node %s", volume.PersistentVolumeClaim.ClaimName, pod.Namespace, pod.Name, nodeName))
+				lvgNamesForTheNode := schedulerCache.GetLVGNamesByNodeName(nodeName)
+				log.Trace(fmt.Sprintf("[populateCache] LVMVolumeGroups from cache for the node %s: %v", nodeName, lvgNamesForTheNode))
 				pvc := pvcs[volume.PersistentVolumeClaim.ClaimName]
 				sc := scs[*pvc.Spec.StorageClassName]
 
@@ -265,7 +282,7 @@ func extractRequestedSize(
 func filterNodes(
 	log logger.Logger,
 	schedulerCache *cache.Cache,
-	nodes *corev1.NodeList,
+	nodeNames *[]string,
 	pod *corev1.Pod,
 	pvcs map[string]*corev1.PersistentVolumeClaim,
 	scs map[string]*v1.StorageClass,
@@ -274,7 +291,7 @@ func filterNodes(
 	// Param "pvcRequests" is a total amount of the pvcRequests space (both Thick and Thin) for Pod (i.e. from every PVC)
 	if len(pvcRequests) == 0 {
 		return &ExtenderFilterResult{
-			Nodes: nodes,
+			NodeNames: nodeNames,
 		}, nil
 	}
 
@@ -347,7 +364,7 @@ func filterNodes(
 	}
 
 	result := &ExtenderFilterResult{
-		Nodes:       &corev1.NodeList{},
+		NodeNames:   &[]string{},
 		FailedNodes: FailedNodesMap{},
 	}
 
@@ -356,27 +373,27 @@ func filterNodes(
 	failedNodesMapMtx := &sync.Mutex{}
 
 	wg := &sync.WaitGroup{}
-	wg.Add(len(nodes.Items))
-	errs := make(chan error, len(nodes.Items)*len(pvcs))
+	wg.Add(len(*nodeNames))
+	errs := make(chan error, len(*nodeNames)*len(pvcs))
 
-	for i, node := range nodes.Items {
-		go func(i int, node corev1.Node) {
-			log.Trace(fmt.Sprintf("[filterNodes] gourutine %d starts the work", i))
+	for i, nodeName := range *nodeNames {
+		go func(i int, nodeName string) {
+			log.Trace(fmt.Sprintf("[filterNodes] gourutine %d starts the work with node %s", i, nodeName))
 			defer func() {
-				log.Trace(fmt.Sprintf("[filterNodes] gourutine %d ends the work", i))
+				log.Trace(fmt.Sprintf("[filterNodes] gourutine %d ends the work with node %s", i, nodeName))
 				wg.Done()
 			}()
 
-			if _, common := commonNodes[node.Name]; !common {
-				log.Debug(fmt.Sprintf("[filterNodes] node %s is not common for used Storage Classes", node.Name))
+			if _, common := commonNodes[nodeName]; !common {
+				log.Debug(fmt.Sprintf("[filterNodes] node %s is not common for used Storage Classes %+v", nodeName, scs))
 				failedNodesMapMtx.Lock()
-				result.FailedNodes[node.Name] = "node is not common for used Storage Classes"
+				result.FailedNodes[nodeName] = fmt.Sprintf("node %s is not common for used Storage Classes", nodeName)
 				failedNodesMapMtx.Unlock()
 				return
 			}
 
 			// we get all LVMVolumeGroups from the node-applicant (which is common for all the PVCs)
-			lvgsFromNode := commonNodes[node.Name]
+			lvgsFromNode := commonNodes[nodeName]
 			hasEnoughSpace := true
 
 			// now we iterate all over the PVCs to see if we can place all of them on the node (does the node have enough space)
@@ -389,11 +406,11 @@ func filterNodes(
 				// we get the specific LVG which the PVC can use on the node as we support only one specified LVG in the Storage Class on each node
 				commonLVG := findMatchedLVG(lvgsFromNode, lvgsFromSC)
 				if commonLVG == nil {
-					err = fmt.Errorf("unable to match Storage Class's LVMVolumeGroup with the node's one, Storage Class: %s, node: %s", *pvc.Spec.StorageClassName, node.Name)
+					err = fmt.Errorf("unable to match Storage Class's LVMVolumeGroup with the node's one, Storage Class: %s, node: %s", *pvc.Spec.StorageClassName, nodeName)
 					errs <- err
 					return
 				}
-				log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s is common for storage class %s and node %s", commonLVG.Name, *pvc.Spec.StorageClassName, node.Name))
+				log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s is common for storage class %s and node %s", commonLVG.Name, *pvc.Spec.StorageClassName, nodeName))
 
 				// see what kind of space does the PVC need
 				switch pvcReq.DeviceType {
@@ -417,7 +434,7 @@ func filterNodes(
 					// we try to find specific ThinPool which the PVC can use in the LVMVolumeGroup
 					targetThinPool := findMatchedThinPool(lvg.Status.ThinPools, commonLVG.Thin.PoolName)
 					if targetThinPool == nil {
-						err = fmt.Errorf("unable to match Storage Class's ThinPools with the node's one, Storage Class: %s; node: %s; lvg Thin pools: %+v; Thin.poolName from StorageClass: %s", *pvc.Spec.StorageClassName, node.Name, lvg.Status.ThinPools, commonLVG.Thin.PoolName)
+						err = fmt.Errorf("unable to match Storage Class's ThinPools with the node's one, Storage Class: %s; node: %s; lvg Thin pools: %+v; Thin.poolName from StorageClass: %s", *pvc.Spec.StorageClassName, nodeName, lvg.Status.ThinPools, commonLVG.Thin.PoolName)
 						errs <- err
 						return
 					}
@@ -446,13 +463,13 @@ func filterNodes(
 
 			if !hasEnoughSpace {
 				failedNodesMapMtx.Lock()
-				result.FailedNodes[node.Name] = "not enough space"
+				result.FailedNodes[nodeName] = "not enough space"
 				failedNodesMapMtx.Unlock()
 				return
 			}
 
-			result.Nodes.Items = append(result.Nodes.Items, node)
-		}(i, node)
+			*result.NodeNames = append(*result.NodeNames, nodeName)
+		}(i, nodeName)
 	}
 	wg.Wait()
 	log.Debug("[filterNodes] goroutines work is done")
@@ -467,8 +484,8 @@ func filterNodes(
 		return nil, err
 	}
 
-	for _, node := range result.Nodes.Items {
-		log.Trace(fmt.Sprintf("[filterNodes] for a Pod %s/%s there is a suitable node: %s", pod.Namespace, pod.Name, node.Name))
+	for _, nodeName := range *result.NodeNames {
+		log.Trace(fmt.Sprintf("[filterNodes] for a Pod %s/%s there is a suitable node: %s", pod.Namespace, pod.Name, nodeName))
 	}
 
 	for node, reason := range result.FailedNodes {
@@ -659,7 +676,7 @@ func getStorageClassesUsedByPVCs(ctx context.Context, cl client.Client, pvcs map
 	result := make(map[string]*v1.StorageClass, len(pvcs))
 	for _, pvc := range pvcs {
 		if pvc.Spec.StorageClassName == nil {
-			err = fmt.Errorf("not StorageClass specified for PVC %s", pvc.Name)
+			err = fmt.Errorf("no StorageClass specified for PVC %s", pvc.Name)
 			return nil, err
 		}
 

--- a/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/func.go
+++ b/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/func.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sds-local-volume-scheduler-extender/pkg/logger"
+)
+
+const (
+	annotationBetaStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+	annotationStorageProvisioner     = "volume.kubernetes.io/storage-provisioner"
+)
+
+func ShouldProcessPod(ctx context.Context, cl client.Client, log logger.Logger, pod *corev1.Pod, targetProvisioner string) (bool, error) {
+	log.Trace(fmt.Sprintf("[ShouldProcessPod] targetProvisioner=%s, pod: %+v", targetProvisioner, pod))
+	var discoveredProvisioner string
+
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			log.Trace(fmt.Sprintf("[ShouldProcessPod] process volume: %+v that has pvc: %+v", volume, volume.PersistentVolumeClaim))
+			pvcName := volume.PersistentVolumeClaim.ClaimName
+			pvc := &corev1.PersistentVolumeClaim{}
+			err := cl.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pvcName}, pvc)
+			if err != nil {
+				return false, fmt.Errorf("[ShouldProcessPod] error getting PVC %s: %v", pvcName, err)
+			}
+
+			log.Trace(fmt.Sprintf("[ShouldProcessPod] get pvc: %+v", pvc))
+			log.Trace(fmt.Sprintf("[ShouldProcessPod] check provisioner in pvc annotations: %+v", pvc.Annotations))
+			provisioner, ok := pvc.Annotations[annotationStorageProvisioner]
+			if !ok {
+				provisioner, ok = pvc.Annotations[annotationBetaStorageProvisioner]
+			}
+
+			if ok {
+				discoveredProvisioner = provisioner
+				log.Trace(fmt.Sprintf("[ShouldProcessPod] discovered provisioner in pvc annotations: %s", discoveredProvisioner))
+			} else if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
+				log.Trace(fmt.Sprintf("[ShouldProcessPod] can't find provisioner in pvc annotations, check in storageClass with name: %s", *pvc.Spec.StorageClassName))
+				storageClass := &storagev1.StorageClass{}
+				err := cl.Get(ctx, client.ObjectKey{Name: *pvc.Spec.StorageClassName}, storageClass)
+				if err != nil {
+					return false, fmt.Errorf("[ShouldProcessPod] error getting StorageClass %s: %v", *pvc.Spec.StorageClassName, err)
+				}
+
+				discoveredProvisioner = storageClass.Provisioner
+				log.Trace(fmt.Sprintf("[ShouldProcessPod] discover provisioner %s in storageClass: %+v", discoveredProvisioner, storageClass))
+			} else if pvc.Spec.VolumeName != "" {
+				log.Trace(fmt.Sprintf("[ShouldProcessPod] can't find provisioner in pvc annotations and StorageClass, check in PV with name: %s", pvc.Spec.VolumeName))
+				pv := &corev1.PersistentVolume{}
+				err := cl.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv)
+				if err != nil {
+					return false, fmt.Errorf("[ShouldProcessPod] error getting PV %s: %v", pvc.Spec.VolumeName, err)
+				}
+
+				if pv.Spec.CSI != nil {
+					discoveredProvisioner = pv.Spec.CSI.Driver
+				}
+
+				log.Trace(fmt.Sprintf("[ShouldProcessPod] discover provisioner %s in PV: %+v", discoveredProvisioner, pv))
+			}
+
+			log.Trace(fmt.Sprintf("[ShouldProcessPod] discovered provisioner: %s", discoveredProvisioner))
+			if discoveredProvisioner == targetProvisioner {
+				log.Trace(fmt.Sprintf("[ShouldProcessPod] provisioner matches targetProvisioner %s. Pod: %s/%s", pod.Namespace, pod.Name, targetProvisioner))
+				return true, nil
+			}
+			log.Trace(fmt.Sprintf("[ShouldProcessPod] provisioner %s doesn't match targetProvisioner %s. Skip volume %s.", discoveredProvisioner, targetProvisioner, volume.Name))
+		}
+	}
+	log.Trace(fmt.Sprintf("[ShouldProcessPod] can't find targetProvisioner %s in pod volumes. Skip pod: %s/%s", targetProvisioner, pod.Namespace, pod.Name))
+	return false, nil
+}

--- a/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/func_test.go
+++ b/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/func_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sds-local-volume-scheduler-extender/pkg/logger"
+)
+
+func TestShouldProcessPod(t *testing.T) {
+	log := logger.Logger{}
+	ctx := context.Background()
+
+	tt := []struct {
+		name                  string
+		pod                   *corev1.Pod
+		objects               []runtime.Object
+		targetProvisioner     string
+		expectedShouldProcess bool
+		expectedError         bool
+	}{
+		{
+			name: "Provisioner in PVC annotations",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "volume1",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc1",
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"volume.beta.kubernetes.io/storage-provisioner": "my-provisioner",
+						},
+					},
+				},
+			},
+			targetProvisioner:     "my-provisioner",
+			expectedShouldProcess: true,
+		},
+		{
+			name: "Provisioner in StorageClass",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "volume2",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc2",
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc2",
+						Namespace: "default",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: stringPtr("sc2"),
+					},
+				},
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "sc2",
+					},
+					Provisioner: "my-provisioner",
+				},
+			},
+			targetProvisioner:     "my-provisioner",
+			expectedShouldProcess: true,
+		},
+		{
+			name: "Provisioner in PV",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "volume3",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc3",
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc3",
+						Namespace: "default",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv3",
+					},
+				},
+				&corev1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pv3",
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver: "my-provisioner",
+							},
+						},
+					},
+				},
+			},
+			targetProvisioner:     "my-provisioner",
+			expectedShouldProcess: true,
+		},
+		{
+			name: "No matching Provisioner",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod4",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "volume4",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc4",
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc4",
+						Namespace: "default",
+					},
+				},
+			},
+			targetProvisioner:     "my-provisioner",
+			expectedShouldProcess: false,
+		},
+		{
+			name: "Error getting PVC",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod5",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "volume5",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "nonexistent-pvc",
+								},
+							},
+						},
+					},
+				},
+			},
+			objects:               []runtime.Object{},
+			targetProvisioner:     "my-provisioner",
+			expectedShouldProcess: false,
+			expectedError:         true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scheme.Scheme
+			_ = corev1.AddToScheme(s)
+			_ = storagev1.AddToScheme(s)
+
+			cl := fake.NewFakeClient(tc.objects...)
+			shouldProcess, err := ShouldProcessPod(ctx, cl, log, tc.pod, tc.targetProvisioner)
+			if (err != nil) != tc.expectedError {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if shouldProcess != tc.expectedShouldProcess {
+				t.Errorf("Expected shouldProcess to be %v, but got %v", tc.expectedShouldProcess, shouldProcess)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/func_test.go
+++ b/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/func_test.go
@@ -227,7 +227,7 @@ func TestShouldProcessPod(t *testing.T) {
 			_ = storagev1.AddToScheme(s)
 
 			cl := fake.NewFakeClient(tc.objects...)
-			shouldProcess, err := ShouldProcessPod(ctx, cl, log, tc.pod, tc.targetProvisioner)
+			shouldProcess, err := shouldProcessPod(ctx, cl, log, tc.pod, tc.targetProvisioner)
 			if (err != nil) != tc.expectedError {
 				t.Fatalf("Unexpected error: %v", err)
 			}

--- a/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/prioritize.go
+++ b/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/prioritize.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -34,68 +35,85 @@ import (
 
 func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 	s.log.Debug("[prioritize] starts serving")
-	var input ExtenderArgs
+	var inputData ExtenderArgs
 	reader := http.MaxBytesReader(w, r.Body, 10<<20)
-	err := json.NewDecoder(reader).Decode(&input)
+	err := json.NewDecoder(reader).Decode(&inputData)
 	if err != nil {
 		s.log.Error(err, "[prioritize] unable to decode a request")
 		http.Error(w, "Bad Request.", http.StatusBadRequest)
 		return
 	}
+	s.log.Trace(fmt.Sprintf("[prioritize] input data: %+v", inputData))
 
-	s.log.Debug(fmt.Sprintf("[prioritize] starts the prioritizing for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	if inputData.NodeNames == nil || len(*inputData.NodeNames) == 0 {
+		s.log.Error(errors.New("no node names in the request"), "[prioritize] unable to get node names from the request")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	nodeNames := inputData.NodeNames
+	s.log.Trace(fmt.Sprintf("[prioritize] node names from the request: %v", nodeNames))
 
-	pvcs, err := getUsedPVC(s.ctx, s.client, s.log, input.Pod)
+	if inputData.Pod == nil {
+		s.log.Error(errors.New("no pod in the request"), "[prioritize] unable to get a Pod from the request")
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	pod := inputData.Pod
+	s.log.Debug(fmt.Sprintf("[prioritize] starts the prioritizeing for Pod %s/%s", pod.Namespace, pod.Name))
+
+	s.log.Debug(fmt.Sprintf("[prioritize] starts the prioritizing for Pod %s/%s", pod.Namespace, pod.Name))
+
+	pvcs, err := getUsedPVC(s.ctx, s.client, s.log, pod)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[prioritize] unable to get PVC from the Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+		s.log.Error(err, fmt.Sprintf("[prioritize] unable to get PVC from the Pod %s/%s", pod.Namespace, pod.Name))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	if len(pvcs) == 0 {
-		s.log.Error(fmt.Errorf("no PVC was found for pod %s in namespace %s", input.Pod.Name, input.Pod.Namespace), fmt.Sprintf("[prioritize] unable to get used PVC for Pod %s", input.Pod.Name))
+		s.log.Error(fmt.Errorf("no PVC was found for pod %s in namespace %s", pod.Name, pod.Namespace), fmt.Sprintf("[prioritize] unable to get used PVC for Pod %s", pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 	for _, pvc := range pvcs {
-		s.log.Trace(fmt.Sprintf("[prioritize] Pod %s/%s uses PVC: %s", input.Pod.Namespace, input.Pod.Name, pvc.Name))
+		s.log.Trace(fmt.Sprintf("[prioritize] Pod %s/%s uses PVC: %s", pod.Namespace, pod.Name, pvc.Name))
 	}
 
 	scs, err := getStorageClassesUsedByPVCs(s.ctx, s.client, pvcs)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[prioritize] unable to get StorageClasses from the PVC for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+		s.log.Error(err, fmt.Sprintf("[prioritize] unable to get StorageClasses from the PVC for Pod %s/%s", pod.Namespace, pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 	for _, sc := range scs {
-		s.log.Trace(fmt.Sprintf("[prioritize] Pod %s/%s uses Storage Class: %s", input.Pod.Namespace, input.Pod.Name, sc.Name))
+		s.log.Trace(fmt.Sprintf("[prioritize] Pod %s/%s uses Storage Class: %s", pod.Namespace, pod.Name, sc.Name))
 	}
 
 	managedPVCs := filterNotManagedPVC(s.log, pvcs, scs)
 	for _, pvc := range managedPVCs {
-		s.log.Trace(fmt.Sprintf("[prioritize] filtered managed PVC %s/%s", pvc.Namespace, pvc.Name))
+		s.log.Trace(fmt.Sprintf("[prioritize] prioritizeed managed PVC %s/%s", pvc.Namespace, pvc.Name))
 	}
 
-	s.log.Debug(fmt.Sprintf("[prioritize] starts to extract pvcRequests size for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[prioritize] starts to extract pvcRequests size for Pod %s/%s", pod.Namespace, pod.Name))
 	pvcRequests, err := extractRequestedSize(s.ctx, s.client, s.log, managedPVCs, scs)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[prioritize] unable to extract request size for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+		s.log.Error(err, fmt.Sprintf("[prioritize] unable to extract request size for Pod %s/%s", pod.Namespace, pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 	}
-	s.log.Debug(fmt.Sprintf("[prioritize] successfully extracted the pvcRequests size for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[prioritize] successfully extracted the pvcRequests size for Pod %s/%s", pod.Namespace, pod.Name))
 
-	s.log.Debug(fmt.Sprintf("[prioritize] starts to score the nodes for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
-	result, err := scoreNodes(s.log, s.cache, input.Nodes, managedPVCs, scs, pvcRequests, s.defaultDivisor)
+	s.log.Debug(fmt.Sprintf("[prioritize] starts to score the nodes for Pod %s/%s", pod.Namespace, pod.Name))
+	result, err := scoreNodes(s.log, s.cache, nodeNames, managedPVCs, scs, pvcRequests, s.defaultDivisor)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[prioritize] unable to score nodes for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+		s.log.Error(err, fmt.Sprintf("[prioritize] unable to score nodes for Pod %s/%s", pod.Namespace, pod.Name))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.log.Debug(fmt.Sprintf("[prioritize] successfully scored the nodes for Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+	s.log.Debug(fmt.Sprintf("[prioritize] successfully scored the nodes for Pod %s/%s", pod.Namespace, pod.Name))
 
 	w.Header().Set("content-type", "application/json")
 	err = json.NewEncoder(w).Encode(result)
 	if err != nil {
-		s.log.Error(err, fmt.Sprintf("[prioritize] unable to encode a response for a Pod %s/%s", input.Pod.Namespace, input.Pod.Name))
+		s.log.Error(err, fmt.Sprintf("[prioritize] unable to encode a response for a Pod %s/%s", pod.Namespace, pod.Name))
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 	s.log.Debug("[prioritize] ends serving")
@@ -104,7 +122,7 @@ func (s *scheduler) prioritize(w http.ResponseWriter, r *http.Request) {
 func scoreNodes(
 	log logger.Logger,
 	schedulerCache *cache.Cache,
-	nodes *corev1.NodeList,
+	nodeNames *[]string,
 	pvcs map[string]*corev1.PersistentVolumeClaim,
 	scs map[string]*v1.StorageClass,
 	pvcRequests map[string]PVCRequest,
@@ -128,31 +146,31 @@ func scoreNodes(
 		}
 	}
 
-	result := make([]HostPriority, 0, len(nodes.Items))
+	result := make([]HostPriority, 0, len(*nodeNames))
 	wg := &sync.WaitGroup{}
-	wg.Add(len(nodes.Items))
-	errs := make(chan error, len(pvcs)*len(nodes.Items))
+	wg.Add(len(*nodeNames))
+	errs := make(chan error, len(pvcs)*len(*nodeNames))
 
-	for i, node := range nodes.Items {
-		go func(i int, node corev1.Node) {
-			log.Debug(fmt.Sprintf("[scoreNodes] gourutine %d starts the work", i))
+	for i, nodeName := range *nodeNames {
+		go func(i int, nodeName string) {
+			log.Debug(fmt.Sprintf("[scoreNodes] gourutine %d starts the work for the node %s", i, nodeName))
 			defer func() {
-				log.Debug(fmt.Sprintf("[scoreNodes] gourutine %d ends the work", i))
+				log.Debug(fmt.Sprintf("[scoreNodes] gourutine %d ends the work for the node %s", i, nodeName))
 				wg.Done()
 			}()
 
-			lvgsFromNode := nodeLVGs[node.Name]
+			lvgsFromNode := nodeLVGs[nodeName]
 			var totalFreeSpaceLeft int64
 			for _, pvc := range pvcs {
 				pvcReq := pvcRequests[pvc.Name]
 				lvgsFromSC := scLVGs[*pvc.Spec.StorageClassName]
 				commonLVG := findMatchedLVG(lvgsFromNode, lvgsFromSC)
 				if commonLVG == nil {
-					err = fmt.Errorf("unable to match Storage Class's LVMVolumeGroup with the node's one, Storage Class: %s, node: %s", *pvc.Spec.StorageClassName, node.Name)
+					err = fmt.Errorf("unable to match Storage Class's LVMVolumeGroup with the node's one, Storage Class: %s, node: %s", *pvc.Spec.StorageClassName, nodeName)
 					errs <- err
 					return
 				}
-				log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s is common for storage class %s and node %s", commonLVG.Name, *pvc.Spec.StorageClassName, node.Name))
+				log.Trace(fmt.Sprintf("[scoreNodes] LVMVolumeGroup %s is common for storage class %s and node %s", commonLVG.Name, *pvc.Spec.StorageClassName, nodeName))
 
 				var freeSpace resource.Quantity
 				lvg := lvgs[commonLVG.Name]
@@ -172,7 +190,7 @@ func scoreNodes(
 				case consts.Thin:
 					thinPool := findMatchedThinPool(lvg.Status.ThinPools, commonLVG.Thin.PoolName)
 					if thinPool == nil {
-						err = fmt.Errorf("unable to match Storage Class's ThinPools with the node's one, Storage Class: %s, node: %s", *pvc.Spec.StorageClassName, node.Name)
+						err = fmt.Errorf("unable to match Storage Class's ThinPools with the node's one, Storage Class: %s, node: %s", *pvc.Spec.StorageClassName, nodeName)
 						log.Error(err, "[scoreNodes] an error occurs while searching for target LVMVolumeGroup")
 						errs <- err
 						return
@@ -186,15 +204,15 @@ func scoreNodes(
 			}
 
 			averageFreeSpace := totalFreeSpaceLeft / int64(len(pvcs))
-			log.Trace(fmt.Sprintf("[scoreNodes] average free space left for the node: %s", node.Name))
+			log.Trace(fmt.Sprintf("[scoreNodes] average free space left for the node: %s", nodeName))
 			score := getNodeScore(averageFreeSpace, divisor)
-			log.Trace(fmt.Sprintf("[scoreNodes] node %s has score %d with average free space left (after all PVC bounded), percent %d", node.Name, score, averageFreeSpace))
+			log.Trace(fmt.Sprintf("[scoreNodes] node %s has score %d with average free space left (after all PVC bounded), percent %d", nodeName, score, averageFreeSpace))
 
 			result = append(result, HostPriority{
-				Host:  node.Name,
+				Host:  nodeName,
 				Score: score,
 			})
-		}(i, node)
+		}(i, nodeName)
 	}
 	wg.Wait()
 

--- a/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/route.go
+++ b/images/sds-local-volume-scheduler-extender/src/pkg/scheduler/route.go
@@ -39,11 +39,11 @@ type scheduler struct {
 
 func (s *scheduler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
-	case "/filter":
+	case "/scheduler/filter":
 		s.log.Debug("[ServeHTTP] filter route starts handling the request")
 		s.filter(w, r)
 		s.log.Debug("[ServeHTTP] filter route ends handling the request")
-	case "/prioritize":
+	case "/scheduler/prioritize":
 		s.log.Debug("[ServeHTTP] prioritize route starts handling the request")
 		s.prioritize(w, r)
 		s.log.Debug("[ServeHTTP] prioritize route ends handling the request")

--- a/openapi/values.yaml
+++ b/openapi/values.yaml
@@ -28,6 +28,23 @@ properties:
           ca:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
+      customSchedulerExtenderCert:
+         type: object
+         default: {}
+         x-required-for-helm:
+           - crt
+           - key
+           - ca
+         properties:
+           crt:
+             type: string
+             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
+           key:
+             type: string
+             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
+           ca:
+             type: string
+             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
   registry:
     type: object
     description: "System field, overwritten by Deckhouse. Don't use"

--- a/templates/sds-local-volume-scheduler-extender/configmap.yaml
+++ b/templates/sds-local-volume-scheduler-extender/configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
 data:
   scheduler-extender-config.yaml: |-
-    listen: "localhost:8099"
+    listen: ":8099"
     health-probe-bind-address: ":8081"
     default-divisor: 1
 {{- if eq .Values.sdsLocalVolume.logLevel "ERROR" }}
@@ -21,6 +21,16 @@ data:
 {{- else if eq .Values.sdsLocalVolume.logLevel "TRACE" }}
     log-level: "4"
     {{- end }}
+
+{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sds-local-volume-scheduler
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+data:
   scheduler-config.yaml: |-
     {{- if semverCompare ">= 1.26" .Values.global.discovery.kubernetesVersion }}
     apiVersion: kubescheduler.config.k8s.io/v1
@@ -31,10 +41,13 @@ data:
     profiles:
       - schedulerName: sds-local-volume
     extenders:
-      - urlPrefix: http://localhost:8099
+      - urlPrefix: https://localhost:8099/scheduler
         filterVerb: filter
         prioritizeVerb: prioritize
         weight: 5
-        enableHTTPS: false
-        httpTimeout: 300000s
-        nodeCacheCapable: false
+        enableHTTPS: true
+        httpTimeout: 300s
+        nodeCacheCapable: true
+        tlsConfig:
+          caData: {{ .Values.sdsLocalVolume.internal.customSchedulerExtenderCert.ca }}
+{{- end }}

--- a/templates/sds-local-volume-scheduler-extender/configmap.yaml
+++ b/templates/sds-local-volume-scheduler-extender/configmap.yaml
@@ -22,7 +22,7 @@ data:
     log-level: "4"
     {{- end }}
 
-{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
+{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/templates/sds-local-volume-scheduler-extender/deployment.yaml
+++ b/templates/sds-local-volume-scheduler-extender/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Chart.Name }}-module-registry
       containers:
-{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
+{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
         - name: kube-scheduler
           {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}
           command:
@@ -140,7 +140,7 @@ spec:
               {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
               {{- include "sds_local_volume_scheduler_extender_resources" . | nindent 14 }}
               {{- end }}
-{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
           ports:
            - containerPort: 8099
              protocol: TCP
@@ -153,7 +153,7 @@ spec:
       - name: scheduler-extender-certs
         secret:
             secretName: scheduler-extender-https-certs
-{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
+{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
       - configMap:
           defaultMode: 420
           name: sds-local-volume-scheduler

--- a/templates/sds-local-volume-scheduler-extender/deployment.yaml
+++ b/templates/sds-local-volume-scheduler-extender/deployment.yaml
@@ -14,14 +14,14 @@ memory: 25Mi
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: sds-local-volume-scheduler
+    name: sds-local-volume-scheduler-extender
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -43,40 +43,41 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler" )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender" )) | nindent 2 }}
 spec:
   minAvailable: {{ include "helm_lib_is_ha_to_value" (list . 1 0) }}
   selector:
     matchLabels:
-      app: sds-local-volume-scheduler
+      app: sds-local-volume-scheduler-extender
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler" )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender" )) | nindent 2 }}
 spec:
   {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: sds-local-volume-scheduler
+      app: sds-local-volume-scheduler-extender
   template:
     metadata:
       labels:
-        app: sds-local-volume-scheduler
+        app: sds-local-volume-scheduler-extender
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 6 }}
       imagePullSecrets:
         - name: {{ .Chart.Name }}-module-registry
       containers:
+{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
         - name: kube-scheduler
           {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}
           command:
@@ -118,6 +119,7 @@ spec:
               {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
               {{- include "kube_scheduler_resources" . | nindent 14 }}
               {{- end }}
+{{- end }}
         - name: sds-local-volume-scheduler-extender
           {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}
           image: {{ include "helm_lib_module_image" (list . "sdsLocalVolumeSchedulerExtender") }}
@@ -126,17 +128,35 @@ spec:
             - sds-local-volume-scheduler-extender
             - --config=/etc/sds-local-volume-scheduler-extender/scheduler-extender-config.yaml
           volumeMounts:
-          - mountPath: /etc/sds-local-volume-scheduler-extender
-            name: scheduler-config
+          - name: scheduler-extender-config
+            mountPath: /etc/sds-local-volume-scheduler-extender
+            readOnly: true
+          - name: scheduler-extender-certs
+            mountPath: /etc/sds-local-volume-scheduler-extender/certs
+            readOnly: true
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
               {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
               {{- include "sds_local_volume_scheduler_extender_resources" . | nindent 14 }}
               {{- end }}
+{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+          ports:
+           - containerPort: 8099
+             protocol: TCP
+{{- end }}
       volumes:
+      - name: scheduler-extender-config
+        configMap:
+          defaultMode: 420
+          name: sds-local-volume-scheduler-extender
+      - name: scheduler-extender-certs
+        secret:
+            secretName: scheduler-extender-https-certs
+{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
       - configMap:
           defaultMode: 420
           name: sds-local-volume-scheduler
         name: scheduler-config
-      serviceAccountName: sds-local-volume-scheduler
+{{- end }}
+      serviceAccountName: sds-local-volume-scheduler-extender

--- a/templates/sds-local-volume-scheduler-extender/kube-scheduler-webhook-configuration.yaml
+++ b/templates/sds-local-volume-scheduler-extender/kube-scheduler-webhook-configuration.yaml
@@ -1,0 +1,18 @@
+{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+apiVersion: deckhouse.io/v1alpha1
+kind: KubeSchedulerWebhookConfiguration
+metadata:
+  name: d8-{{ .Chart.Name }}
+webhooks:
+- weight: 5
+  failurePolicy: Ignore
+  clientConfig:
+    service:
+      name: {{ .Chart.Name }}-scheduler-extender
+      namespace: d8-{{ .Chart.Name }}
+      port: 8099
+      path: /scheduler
+    caBundle: {{ .Values.sdsLocalVolume.internal.customSchedulerExtenderCert.ca }}
+  timeoutSeconds: 5
+
+{{- end }}

--- a/templates/sds-local-volume-scheduler-extender/kube-scheduler-webhook-configuration.yaml
+++ b/templates/sds-local-volume-scheduler-extender/kube-scheduler-webhook-configuration.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
 apiVersion: deckhouse.io/v1alpha1
 kind: KubeSchedulerWebhookConfiguration
 metadata:

--- a/templates/sds-local-volume-scheduler-extender/rbac-for-us.yaml
+++ b/templates/sds-local-volume-scheduler-extender/rbac-for-us.yaml
@@ -2,44 +2,44 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: d8:{{ .Chart.Name }}:sds-local-volume-scheduler-kube-scheduler
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+  name: d8:{{ .Chart.Name }}:sds-local-volume-scheduler-extender-kube-scheduler
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:kube-scheduler
 subjects:
   - kind: ServiceAccount
-    name: sds-local-volume-scheduler
+    name: sds-local-volume-scheduler-extender
     namespace: d8-{{ .Chart.Name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: d8:{{ .Chart.Name }}:sds-local-volume-scheduler-volume-scheduler
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+  name: d8:{{ .Chart.Name }}:sds-local-volume-scheduler-extender-volume-scheduler
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:volume-scheduler
 subjects:
   - kind: ServiceAccount
-    name: sds-local-volume-scheduler
+    name: sds-local-volume-scheduler-extender
     namespace: d8-{{ .Chart.Name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -54,29 +54,29 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sds-local-volume-scheduler
+  name: sds-local-volume-scheduler-extender
 subjects:
   - kind: ServiceAccount
-    name: sds-local-volume-scheduler
+    name: sds-local-volume-scheduler-extender
     namespace: d8-{{ .Chart.Name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: d8:{{ .Chart.Name }}:sds-local-volume-scheduler:extension-apiserver-authentication-reader
+  name: d8:{{ .Chart.Name }}:sds-local-volume-scheduler-extender:extension-apiserver-authentication-reader
   namespace: kube-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler" )) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender" )) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
   - kind: ServiceAccount
-    name: sds-local-volume-scheduler
+    name: sds-local-volume-scheduler-extender
     namespace: d8-{{ .Chart.Name }}

--- a/templates/sds-local-volume-scheduler-extender/secret.yaml
+++ b/templates/sds-local-volume-scheduler-extender/secret.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scheduler-extender-https-certs
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender")) | nindent 2 }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ .Values.sdsLocalVolume.internal.customSchedulerExtenderCert.ca }}
+  tls.crt: {{ .Values.sdsLocalVolume.internal.customSchedulerExtenderCert.crt }}
+  tls.key: {{ .Values.sdsLocalVolume.internal.customSchedulerExtenderCert.key }}

--- a/templates/sds-local-volume-scheduler-extender/service.yaml
+++ b/templates/sds-local-volume-scheduler-extender/service.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.64" .Values.global.deckhouseVersion) }}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/sds-local-volume-scheduler-extender/service.yaml
+++ b/templates/sds-local-volume-scheduler-extender/service.yaml
@@ -1,0 +1,18 @@
+{{- if or (eq "dev" .Values.global.deckhouseVersion) (semverCompare ">=1.63" .Values.global.deckhouseVersion) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-scheduler-extender
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-scheduler-extender" )) | nindent 2 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8099
+      targetPort: 8099
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Chart.Name }}-scheduler-extender
+{{- end }}

--- a/templates/webhooks/webhook.yaml
+++ b/templates/webhooks/webhook.yaml
@@ -1,4 +1,4 @@
-# {{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
+{{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -30,7 +30,7 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
     timeoutSeconds: 5
-# {{- end }}
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/templates/webhooks/webhook.yaml
+++ b/templates/webhooks/webhook.yaml
@@ -1,4 +1,4 @@
-# {{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
+# {{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.64" .Values.global.deckhouseVersion) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/templates/webhooks/webhook.yaml
+++ b/templates/webhooks/webhook.yaml
@@ -1,3 +1,4 @@
+# {{- if and (not (eq "dev" .Values.global.deckhouseVersion)) (semverCompare "<1.63" .Values.global.deckhouseVersion) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -29,7 +30,7 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
     timeoutSeconds: 5
-
+# {{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR transitions from using a dedicated scheduler with an extender for pods that utilize specific PVCs with `local.csi.storage.deckhouse.io` provisioner to a centralized approach provided by Deckhouse. Previously, a separate scheduler was required for each SDS module. With the introduction of the `KubeSchedulerWebhookConfiguration` resource in Deckhouse, we now configure the extender-scheduler directly within the default scheduler, eliminating the need for module-specific schedulers.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The previous method required maintaining a separate scheduler for each SDS module, leading to complexity and potential overhead. By adopting the `KubeSchedulerWebhookConfiguration`, we streamline the configuration process, reduce resource duplication, and centralize scheduler-extender configuration. This transition simplifies management and aligns with Deckhouse's best practices.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Centralized management of the scheduler-extender through the default scheduler.
- Removal of module-specific schedulers, reducing complexity and resource overhead.
- Improved alignment with Deckhouse's recommended practices for Kubernetes scheduling.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
