### PR TITLE
Remove http server healthchecks

### DIFF
--- a/images/sds-local-volume-csi/src/cmd/main.go
+++ b/images/sds-local-volume-csi/src/cmd/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -51,14 +50,6 @@ var (
 		sv1.AddToScheme,
 	}
 )
-
-func healthHandler(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	_, err := fmt.Fprint(w, "OK")
-	if err != nil {
-		klog.Fatalf("Error while generating healthcheck, err: %s", err.Error())
-	}
-}
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -97,15 +88,6 @@ func main() {
 	cl, err := client.New(kConfig, client.Options{
 		Scheme: scheme,
 	})
-
-	http.HandleFunc("/healthz", healthHandler)
-	http.HandleFunc("/readyz", healthHandler)
-	go func() {
-		err = http.ListenAndServe(cfgParams.HealthProbeBindAddress, nil)
-		if err != nil {
-			log.Error(err, "[main] create probes")
-		}
-	}()
 
 	drv, err := driver.NewDriver(cfgParams.CsiAddress, cfgParams.DriverName, cfgParams.Address, &cfgParams.NodeName, log, cl)
 	if err != nil {


### PR DESCRIPTION
## Description
We are removing http server healthchecks, which are not used.

## Why do we need it, and what problem does it solve?
Code become cleaner.

## What is the expected result?
Helathchecks should keep working va liveness-probe container

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.
