### PR TITLE
[csi] Add a separate ServiceAccount for the csi-node

### DIFF
--- a/images/sds-local-volume-controller/src/go.mod
+++ b/images/sds-local-volume-controller/src/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.20.0
 	github.com/onsi/gomega v1.34.1

--- a/images/sds-local-volume-controller/src/go.sum
+++ b/images/sds-local-volume-controller/src/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d h1:I5Bv75VPlH9AdBIOF4a1RIVRAr+zas8CMjeZ6pzJ7eE=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d/go.mod h1:ro/TIWC/cbDPgjaCzJkbrekzp1CqPzgAzGdNUnww+Ps=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911 h1:FSADbTFYKY3eOTvXEV5LxUzOmJ+BsZ6+WO8hQsbJN7s=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911/go.mod h1:bhgBeuAdLlDc9EQ5qI+/18iRj8Jfr2qfFwE1QnIoQM4=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=

--- a/images/sds-local-volume-csi/src/go.mod
+++ b/images/sds-local-volume-csi/src/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/container-storage-interface/spec v1.10.0
 	github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787
 	github.com/deckhouse/sds-local-volume/lib/go/common v0.0.0-20250215220933-9c8f9f5ab53d
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250213122438-37fad98a996a
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911
 	github.com/go-logr/logr v1.4.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0

--- a/images/sds-local-volume-csi/src/go.sum
+++ b/images/sds-local-volume-csi/src/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250213122438-37fad98a996a h1:C/WUqgXGuPx9gEFLNPGh4sNZDW2zEW35yqcicovYCuE=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250213122438-37fad98a996a/go.mod h1:ro/TIWC/cbDPgjaCzJkbrekzp1CqPzgAzGdNUnww+Ps=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911 h1:FSADbTFYKY3eOTvXEV5LxUzOmJ+BsZ6+WO8hQsbJN7s=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911/go.mod h1:bhgBeuAdLlDc9EQ5qI+/18iRj8Jfr2qfFwE1QnIoQM4=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/images/sds-local-volume-csi/src/pkg/kubutils/kubernetes.go
+++ b/images/sds-local-volume-csi/src/pkg/kubutils/kubernetes.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2024 Flant JSC
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,13 +21,18 @@ import (
 )
 
 func KubernetesDefaultConfigCreate() (*rest.Config, error) {
+	config, err := rest.InClusterConfig()
+	if err == nil {
+		return config, nil
+	}
+
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{},
 	)
 
 	// Get a config to talk to API server
-	config, err := clientConfig.ClientConfig()
+	config, err = clientConfig.ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("config kubernetes error %w", err)
 	}

--- a/images/sds-local-volume-scheduler-extender/src/go.mod
+++ b/images/sds-local-volume-scheduler-extender/src/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/spf13/cobra v1.8.1

--- a/images/sds-local-volume-scheduler-extender/src/go.sum
+++ b/images/sds-local-volume-scheduler-extender/src/go.sum
@@ -7,8 +7,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d h1:I5Bv75VPlH9AdBIOF4a1RIVRAr+zas8CMjeZ6pzJ7eE=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d/go.mod h1:ro/TIWC/cbDPgjaCzJkbrekzp1CqPzgAzGdNUnww+Ps=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911 h1:FSADbTFYKY3eOTvXEV5LxUzOmJ+BsZ6+WO8hQsbJN7s=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911/go.mod h1:bhgBeuAdLlDc9EQ5qI+/18iRj8Jfr2qfFwE1QnIoQM4=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=

--- a/images/webhooks/src/go.mod
+++ b/images/webhooks/src/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787
-	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d
+	github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911
 	github.com/sirupsen/logrus v1.9.3
 	github.com/slok/kubewebhook/v2 v2.6.0
 	k8s.io/api v0.30.3

--- a/images/webhooks/src/go.sum
+++ b/images/webhooks/src/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787 h1:YYeoWACJsEOqNcQ/RWDsF82hihNYZKlYZAJopvdeKrQ=
 github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787/go.mod h1:LBLI26oEmeAMYTSRFFFljP8AOk4kqJEwHcf4fYnyzME=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d h1:I5Bv75VPlH9AdBIOF4a1RIVRAr+zas8CMjeZ6pzJ7eE=
-github.com/deckhouse/sds-node-configurator/api v0.0.0-20250114161813-c1a8b09cd47d/go.mod h1:ro/TIWC/cbDPgjaCzJkbrekzp1CqPzgAzGdNUnww+Ps=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911 h1:FSADbTFYKY3eOTvXEV5LxUzOmJ+BsZ6+WO8hQsbJN7s=
+github.com/deckhouse/sds-node-configurator/api v0.0.0-20250225084914-1778068d1911/go.mod h1:bhgBeuAdLlDc9EQ5qI+/18iRj8Jfr2qfFwE1QnIoQM4=
 github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapwQtU84iWk=
 github.com/emicklei/go-restful/v3 v3.12.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=

--- a/templates/sds-local-volume-csi/controller.yaml
+++ b/templates/sds-local-volume-csi/controller.yaml
@@ -301,8 +301,8 @@ spec:
         - name: {{ .Chart.Name }}-module-registry
       restartPolicy: Always
       schedulerName: default-scheduler
-      serviceAccount: default
-      serviceAccountName: default
+      serviceAccount: sds-local-volume-csi-node
+      serviceAccountName: sds-local-volume-csi-node
       terminationGracePeriodSeconds: 30
       volumes:
         - hostPath:

--- a/templates/sds-local-volume-csi/rbac-for-us.yaml
+++ b/templates/sds-local-volume-csi/rbac-for-us.yaml
@@ -1,4 +1,11 @@
 {{- include "helm_lib_csi_controller_rbac" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sds-local-volume-csi-node
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "sds-local-volume-csi-node")) | nindent 2 }}
 
 ---
 kind: ClusterRole


### PR DESCRIPTION
## Description
Add a separate ServiceAccount for the csi-node.

## Why do we need it, and what problem does it solve?
Fix the csi-node pods startup after adding the [Deckhouse hook](https://github.com/deckhouse/deckhouse/blob/b2e60c1d9020a7366c214795dbc9d05ed7717316/modules/002-deckhouse/hooks/disable_sa_token_automount.go). 

## What is the expected result?
Ensure the csi-node pods start successfully.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
