### PR TITLE
[Doc ] add restriction of usage thin LVGs in LocalStorageClasses

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -258,7 +258,7 @@ kubectl -n d8-sds-local-volume get pod -owide
      volumeBindingMode: WaitForFirstConsumer
    EOF
    ```
-> **Caution.** A `LocalStorageClass` with `type: Thick` cannot use an LVG that includes even a single thin pool.
+> **Caution.** A `LocalStorageClass` with `type: Thick` cannot use an LocalVolumeGroup that includes even a single thin pool.
 
 1. Wait for the created LocalStorageClass resource to become `Created`:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -258,6 +258,7 @@ kubectl -n d8-sds-local-volume get pod -owide
      volumeBindingMode: WaitForFirstConsumer
    EOF
    ```
+> **Caution.** A `LocalStorageClass` with `type: Thick` cannot use an LVG that includes even a single thin pool.
 
 1. Wait for the created LocalStorageClass resource to become `Created`:
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -257,7 +257,7 @@ kubectl -n d8-sds-local-volume get pod -owide
    EOF
    ```
 
-> **Внимание.** В `LocalStorageClass` с `type: Thick` нельзя использовать LVG, содержащие хотя бы один thin pool.
+> **Внимание.** В `LocalStorageClass` с `type: Thick` нельзя использовать LocalVolumeGroup, содержащие хотя бы один thin pool.
 
 1. Дождитесь, когда созданный ресурс LocalStorageClass перейдет в состояние `Created`:
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -257,6 +257,8 @@ kubectl -n d8-sds-local-volume get pod -owide
    EOF
    ```
 
+> **Внимание.** В `LocalStorageClass` с `type: Thick` нельзя использовать LVG, содержащие хотя бы один thin pool.
+
 1. Дождитесь, когда созданный ресурс LocalStorageClass перейдет в состояние `Created`:
 
    ```shell


### PR DESCRIPTION
## Description
Documentation misses an important restriction about LVG usage in LocalStorageClasses. This fix adds it.

## Why do we need it, and what problem does it solve?
Keep documentation up to date

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
