### PR TITLE
[internal] fix panic while controller processing LVGs without nodes in status

### DIFF
--- a/images/sds-local-volume-csi/pkg/utils/func.go
+++ b/images/sds-local-volume-csi/pkg/utils/func.go
@@ -458,7 +458,9 @@ func GetStorageClassLVGsAndParameters(
 		_, ok := storageClassLVGParametersMap[lvg.Name]
 		if ok {
 			log.Info(fmt.Sprintf("[GetStorageClassLVGs] found lvg from storage class: %s", lvg.Name))
-			log.Info(fmt.Sprintf("[GetStorageClassLVGs] lvg.Status.Nodes[0].Name: %s", lvg.Status.Nodes[0].Name))
+			if len(lvg.Status.Nodes) > 0 {
+				log.Info(fmt.Sprintf("[GetStorageClassLVGs] lvg.Status.Nodes[0].Name: %s", lvg.Status.Nodes[0].Name))
+			}
 			storageClassLVGs = append(storageClassLVGs, lvg)
 		} else {
 			log.Trace(fmt.Sprintf("[GetStorageClassLVGs] skip lvg: %s", lvg.Name))


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

If there is no nodes in LVG status, there can be panic
This PR fix it

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct controller work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
