### PR TITLE
[internal] add volumesnapshotclassname annotations to storageclasses

### DIFF
--- a/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_func.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_func.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
-	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/logger"
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/internal"
+	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/logger"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
 
@@ -463,11 +463,11 @@ func configureStorageClass(lsc *slv.LocalStorageClass) (*v1.StorageClass, error)
 			APIVersion: StorageClassAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       lsc.Name,
-			Namespace:  lsc.Namespace,
+			Name:      lsc.Name,
+			Namespace: lsc.Namespace,
 			Annotations: map[string]string{
 				internal.SLVStorageClassVolumeSnapshotClassAnnotationKey: internal.SLVStorageClassVolumeSnapshotClassAnnotationValue,
-			},			
+			},
 			Finalizers: []string{LocalStorageClassFinalizerName},
 		},
 		Provisioner:          LocalStorageClassProvisioner,

--- a/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_func.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_func.go
@@ -30,6 +30,7 @@ import (
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/logger"
+	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/internal"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
 
@@ -464,6 +465,9 @@ func configureStorageClass(lsc *slv.LocalStorageClass) (*v1.StorageClass, error)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       lsc.Name,
 			Namespace:  lsc.Namespace,
+			Annotations: map[string]string{
+				internal.SLVStorageClassVolumeSnapshotClassAnnotationKey: internal.SLVStorageClassVolumeSnapshotClassAnnotationValue,
+			},			
 			Finalizers: []string{LocalStorageClassFinalizerName},
 		},
 		Provisioner:          LocalStorageClassProvisioner,
@@ -471,6 +475,15 @@ func configureStorageClass(lsc *slv.LocalStorageClass) (*v1.StorageClass, error)
 		ReclaimPolicy:        &reclaimPolicy,
 		AllowVolumeExpansion: &AllowVolumeExpansion,
 		VolumeBindingMode:    &volumeBindingMode,
+	}
+
+	if lsc.Labels != nil {
+		sc.Labels = lsc.Labels
+		sc.Labels[internal.SLVStorageManagedLabelKey] = internal.SLVStorageClassCtrlName
+	} else {
+		sc.Labels = map[string]string{
+			internal.SLVStorageManagedLabelKey: internal.SLVStorageClassCtrlName,
+		}
 	}
 
 	return sc, nil

--- a/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_test.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_test.go
@@ -160,8 +160,10 @@ var _ = Describe(controller.LocalStorageClassCtrlName, func() {
 		sc := &v1.StorageClass{}
 		err := cl.Get(ctx, client.ObjectKey{Name: nameForLocalStorageClass}, sc)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Labels).To(HaveLen(1))
+		Expect(sc.Labels).To(HaveKeyWithValue(internal.SLVStorageManagedLabelKey, internal.SLVStorageClassCtrlName))
 		Expect(sc.Annotations).To(HaveLen(1))
-		Expect(sc.Annotations).To(HaveKeyWithValue(internal.SLVStorageManagedLabelKey, internal.SLVStorageClassCtrlName))
+		Expect(sc.Annotations).To(HaveKeyWithValue(internal.SLVStorageClassVolumeSnapshotClassAnnotationKey, internal.SLVStorageClassVolumeSnapshotClassAnnotationValue))
 	})
 
 	It("Update_local_sc_remove_existing_lvg", func() {

--- a/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_test.go
+++ b/images/sds-local-volume-controller/pkg/controller/local_storage_class_watcher_test.go
@@ -31,6 +31,7 @@ import (
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/controller"
+	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/internal"
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-controller/pkg/logger"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
@@ -115,23 +116,6 @@ var _ = Describe(controller.LocalStorageClassCtrlName, func() {
 		performStandartChecksForSC(sc, lvgSpec, nameForLocalStorageClass, controller.LocalStorageClassLvmType, controller.LVMThickType, reclaimPolicyDelete, volumeBindingModeWFFC, controller.DefaultFSType)
 	})
 
-	It("Annotate_sc_as_default_sc", func() {
-		sc := &v1.StorageClass{}
-		err := cl.Get(ctx, client.ObjectKey{Name: nameForLocalStorageClass}, sc)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sc.Annotations).To(BeNil())
-
-		sc.Annotations = map[string]string{
-			controller.StorageClassDefaultAnnotationKey: controller.StorageClassDefaultAnnotationValTrue,
-		}
-
-		err = cl.Update(ctx, sc)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sc.Annotations).To(HaveLen(1))
-		Expect(sc.Annotations).To(HaveKeyWithValue(controller.StorageClassDefaultAnnotationKey, controller.StorageClassDefaultAnnotationValTrue))
-
-	})
-
 	It("Update_local_sc_add_existing_lvg", func() {
 		lvgSpec := []slv.LocalStorageClassLVG{
 			{Name: existingThickLVG1Name},
@@ -177,8 +161,7 @@ var _ = Describe(controller.LocalStorageClassCtrlName, func() {
 		err := cl.Get(ctx, client.ObjectKey{Name: nameForLocalStorageClass}, sc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sc.Annotations).To(HaveLen(1))
-		Expect(sc.Annotations).To(HaveKeyWithValue(controller.StorageClassDefaultAnnotationKey, controller.StorageClassDefaultAnnotationValTrue))
-
+		Expect(sc.Annotations).To(HaveKeyWithValue(internal.SLVStorageManagedLabelKey, internal.SLVStorageClassCtrlName))
 	})
 
 	It("Update_local_sc_remove_existing_lvg", func() {

--- a/images/sds-local-volume-controller/pkg/internal/const.go
+++ b/images/sds-local-volume-controller/pkg/internal/const.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+const (
+	SLVStorageClassCtrlName 							= "d8-sds-local-volume-storage-class-controller"
+	SLVStorageClassVolumeSnapshotClassAnnotationKey 	= "storage.deckhouse.io/volumesnapshotclass"
+	SLVStorageClassVolumeSnapshotClassAnnotationValue 	= "sds-local-volume-snapshot-class"
+	SLVStorageManagedLabelKey                       	= "storage.deckhouse.io/managed-by"
+)

--- a/images/sds-local-volume-controller/pkg/internal/const.go
+++ b/images/sds-local-volume-controller/pkg/internal/const.go
@@ -17,8 +17,8 @@ limitations under the License.
 package internal
 
 const (
-	SLVStorageClassCtrlName 							= "d8-sds-local-volume-storage-class-controller"
-	SLVStorageClassVolumeSnapshotClassAnnotationKey 	= "storage.deckhouse.io/volumesnapshotclass"
-	SLVStorageClassVolumeSnapshotClassAnnotationValue 	= "sds-local-volume-snapshot-class"
-	SLVStorageManagedLabelKey                       	= "storage.deckhouse.io/managed-by"
+	SLVStorageClassCtrlName                           = "d8-sds-local-volume-storage-class-controller"
+	SLVStorageClassVolumeSnapshotClassAnnotationKey   = "storage.deckhouse.io/volumesnapshotclass"
+	SLVStorageClassVolumeSnapshotClassAnnotationValue = "sds-local-volume-snapshot-class"
+	SLVStorageManagedLabelKey                         = "storage.deckhouse.io/managed-by"
 )


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add auto VolumeSnapshotClass annotations to StorageClasses

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct snapshot work

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
