### PR TITLE
[internal] Add checksum annotation for sds-local-volume-scheduler-extender deployment

### DIFF
--- a/templates/sds-local-volume-scheduler-extender/deployment.yaml
+++ b/templates/sds-local-volume-scheduler-extender/deployment.yaml
@@ -69,6 +69,8 @@ spec:
       app: sds-local-volume-scheduler-extender
   template:
     metadata:
+      annotations:
+        checksum/ca: {{ .Values.sdsLocalVolume.internal.customSchedulerExtenderCert.ca | sha256sum | quote }}
       labels:
         app: sds-local-volume-scheduler-extender
     spec:

--- a/templates/webhooks/deployment.yaml
+++ b/templates/webhooks/deployment.yaml
@@ -55,7 +55,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/ca: {{ .Values.sdsLocalVolume.internal.customWebhookCert.ca | sha256sum | quote }}    
+        checksum/ca: {{ .Values.sdsLocalVolume.internal.customWebhookCert.ca | sha256sum | quote }}
       labels:
         app: webhooks
     spec:


### PR DESCRIPTION
### Description
This pull request introduces a change to the deployment file for `sds-local-volume-scheduler-extender`. Specifically, a `checksum/ca` annotation has been added, calculated based on the `customSchedulerExtenderCert.ca` certificate.

### Why do we need it, and what problem does it solve?
The addition of the `checksum/ca` annotation allows Kubernetes to automatically restart the `sds-local-volume-scheduler-extender` pods when the certificate changes, ensuring they remain up-to-date and secure. This change enhances configuration management and automates certificate updates.

### What is the expected result?
After applying this change, the `sds-local-volume-scheduler-extender` pods will automatically restart when their certificate is updated. This ensures that the most current version of the certificate is always in use, thereby improving the reliability and security of the system.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
