### PR TITLE
[werf] Add DISTRO_PACKAGES_PROXY to giterminism secrets allowValueIds

### DIFF
--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -18,6 +18,7 @@ config:
     allowValueIds:
       - GOPROXY
       - SOURCE_REPO
+      - DISTRO_PACKAGES_PROXY
   stapel:
     mount:
       allowBuildDir: true


### PR DESCRIPTION
## Description

Adds `DISTRO_PACKAGES_PROXY` to `secrets.allowValueIds` in `werf-giterminism.yaml` so werf giterminism allows that secret value id in builds. For `sds-replicated-volume`, a `secrets` block is introduced to match other modules that already expose `DISTRO_PACKAGES_PROXY` under `goTemplateRendering.allowEnvVariables`.

## Changelog entries

```changes
section: ci
type: chore
summary: Allow DISTRO_PACKAGES_PROXY in werf giterminism secrets allowValueIds.
```
