### PR TITLE
fix(controller): propagate LocalStorageClass labels to managed k8s StorageClass

### DIFF
--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -14,6 +14,11 @@
 ---
 image: images-digests
 fromImage: builder/alpine
+import:
+  - image: tools/jq
+    add: /usr/bin/jq
+    to: /usr/bin/jq
+    before: setup
 dependencies:
 {{- range $ImageID := $ImagesIDList }}
   {{- $ImageNameCamel  := $ImageID | splitList "/" | last  | camelcase | untitle }}
@@ -24,8 +29,6 @@ dependencies:
       targetEnv: MODULE_IMAGE_DIGEST_{{ $ImageNameCamel }}
 {{- end }}
 shell:
-  beforeInstall:
-  - apk add --no-cache jq
   setup:
     - |
       env | grep MODULE_IMAGE_DIGEST | jq -Rn '

--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -14,11 +14,6 @@
 ---
 image: images-digests
 fromImage: builder/alpine
-import:
-  - image: tools/jq
-    add: /usr/bin/jq
-    to: /usr/bin/jq
-    before: setup
 dependencies:
 {{- range $ImageID := $ImagesIDList }}
   {{- $ImageNameCamel  := $ImageID | splitList "/" | last  | camelcase | untitle }}
@@ -29,6 +24,8 @@ dependencies:
       targetEnv: MODULE_IMAGE_DIGEST_{{ $ImageNameCamel }}
 {{- end }}
 shell:
+  beforeInstall:
+  - apk add --no-cache jq
   setup:
     - |
       env | grep MODULE_IMAGE_DIGEST | jq -Rn '

--- a/images/controller/pkg/controller/local_storage_class_watcher.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher.go
@@ -144,8 +144,10 @@ func RunLocalStorageClassWatcherController(
 			oldLsc := e.ObjectOld
 			newLsc := e.ObjectNew
 
-			if reflect.DeepEqual(oldLsc.Spec, newLsc.Spec) && newLsc.DeletionTimestamp == nil {
-				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the LocalStorageClass %s has no Spec field updates. It will not be reconciled", newLsc.Name))
+			if reflect.DeepEqual(oldLsc.Spec, newLsc.Spec) &&
+				reflect.DeepEqual(oldLsc.Labels, newLsc.Labels) &&
+				newLsc.DeletionTimestamp == nil {
+				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the LocalStorageClass %s has no Spec or Labels updates. It will not be reconciled", newLsc.Name))
 				return
 			}
 

--- a/images/controller/pkg/controller/local_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher_func.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -246,6 +247,10 @@ func hasSCDiff(sc *v1.StorageClass, lsc *slv.LocalStorageClass) (bool, error) {
 		return true, nil
 	}
 
+	if !labelsMatchLSC(sc.Labels, lsc.Labels) {
+		return true, nil
+	}
+
 	if len(currentLVGs) != len(lsc.Spec.LVM.LVMVolumeGroups) {
 		return true, nil
 	}
@@ -269,6 +274,18 @@ func hasSCDiff(sc *v1.StorageClass, lsc *slv.LocalStorageClass) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// labelsMatchLSC reports whether the labels of the existing StorageClass match
+// the labels propagated from the LocalStorageClass (CR labels + managed-by).
+func labelsMatchLSC(scLabels, lscLabels map[string]string) bool {
+	expected := make(map[string]string, len(lscLabels)+1)
+	for k, v := range lscLabels {
+		expected[k] = v
+	}
+	expected[internal.SLVStorageManagedLabelKey] = internal.SLVStorageClassCtrlName
+
+	return reflect.DeepEqual(scLabels, expected)
 }
 
 func getLVGFromSCParams(sc *v1.StorageClass) ([]slv.LocalStorageClassLVG, error) {


### PR DESCRIPTION
## Summary

- The watcher's `UpdateFunc` previously ignored events where only `metadata.labels` changed (it filtered out events with unchanged `Spec`).
- `hasSCDiff` only compared LVM parameters, so even when an event reached reconcile a labels-only change would not trigger `recreateStorageClass`.
- Now `UpdateFunc` also tracks `Labels`, and `hasSCDiff` compares the existing `StorageClass` labels with the expected ones (CR labels + `managed-by`) via a new `labelsMatchLSC` helper, so labels are correctly propagated to the managed `storage.k8s.io/StorageClass` on every CR update.

## Test plan

- [ ] Create a `LocalStorageClass`, confirm labels appear on the managed `StorageClass`.
- [ ] Add a new label to an existing `LocalStorageClass`, confirm it appears on the `StorageClass` without manual recreation.
- [ ] Remove a label from the `LocalStorageClass`, confirm it is removed from the `StorageClass`.
- [ ] Confirm the `storage.deckhouse.io/sds-local-volume-managed-by` label is always preserved.