### PR TITLE
docs: bump ModuleConfig examples to version 2

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,7 @@ All commands must be run on a machine with access to the Kubernetes API and admi
      name: sds-local-volume
    spec:
      enabled: true
+     version: 2
    EOF
    ```
 

--- a/docs/CONFIGURATION.ru.md
+++ b/docs/CONFIGURATION.ru.md
@@ -23,6 +23,7 @@ weight: 3
      name: sds-local-volume
    spec:
      enabled: true
+     version: 2
    EOF
    ```
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -48,6 +48,7 @@ All commands below must be run on a machine with access to the Kubernetes API an
      name: sds-local-volume
    spec:
      enabled: true
+     version: 2
    EOF
    ```
 

--- a/docs/QUICK_START.ru.md
+++ b/docs/QUICK_START.ru.md
@@ -48,6 +48,7 @@ weight: 2
      name: sds-local-volume
    spec:
      enabled: true
+     version: 2
    EOF
    ```
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -194,9 +194,10 @@ The module uses nodes that have the labels specified in the `nodeSelector` field
        dataNodes:
          nodeSelector:
            my-custom-label-key: my-custom-label-value
+     version: 2
    status:
      message: ""
-     version: "1"
+     version: 2
    ```
 
 1. Run the command to view labels in the `nodeSelector` field:

--- a/docs/USAGE.ru.md
+++ b/docs/USAGE.ru.md
@@ -194,9 +194,10 @@ d8 k annotate storageclasses.storage.k8s.io <storageClassName> storageclass.kube
        dataNodes:
          nodeSelector:
            my-custom-label-key: my-custom-label-value
+     version: 2
    status:
      message: ""
-     version: "1"
+     version: 2
    ```
 
 1. Выполните команду для просмотра меток в поле `nodeSelector`:


### PR DESCRIPTION
## Description

The module's openapi (`openapi/config-values.yaml`) declares `x-config-version: 2`, and the only conversion present (`openapi/conversions/v2.yaml`) targets version 2 (it removes the deprecated `enableThinProvisioning` parameter — see CHANGELOG `v0.3.18`/`v0.3.19`). User-facing docs, however, still showed `ModuleConfig` snippets without `spec.version` and a sample output with `status.version: "1"`.

This PR brings the documentation examples in line with the actual CR / openapi version:

- `docs/CONFIGURATION.md`, `docs/CONFIGURATION.ru.md` — added `spec.version: 2` to the enabling example.
- `docs/QUICK_START.md`, `docs/QUICK_START.ru.md` — added `spec.version: 2` to the enabling example.
- `docs/USAGE.md`, `docs/USAGE.ru.md` — added `spec.version: 2` and replaced `status.version: "1"` with `status.version: 2` in the `d8 k edit mc sds-local-volume` example output.

No code, hooks, CRDs, helm templates, or runtime behavior are touched — documentation only.

## Why do we need it, and what problem does it solve?

The displayed `version: 1` did not match what the cluster would actually show for a freshly created `ModuleConfig/sds-local-volume`:

- A user copying the `ModuleConfig` from the docs would create a resource pinned to a deprecated v1 schema (which Deckhouse then converts to v2). At minimum this confuses readers comparing their `kubectl get mc sds-local-volume -oyaml` output with the documented example.
- The `Selecting nodes for module operation` section showed a fake `status.version: "1"` for a module whose current config version is `2`, which is misleading and contradicts the openapi spec.

## What is the expected result?

- Diff is documentation-only; rendered docs (en/ru) for CONFIGURATION, QUICK_START and USAGE show `version: 2` everywhere the `sds-local-volume` `ModuleConfig` is illustrated.
- No CR schema, controller behavior, or chart output changes.
- After this PR the snippets are consistent with `openapi/config-values.yaml` (`x-config-version: 2`) and `openapi/conversions/v2.yaml`.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.