### PR TITLE
chore(werf): migrate to container-base v1.1.2

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -55,6 +55,10 @@ linters-settings:
   module:
     oss:
       disable: true
+  no-cyrillic:
+    exclude-rules:
+      directories:
+        - hack/
   openapi:
     exclude-rules:
       enum:

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.0.51"
+  BASE_IMAGES_VERSION: "v1.1.2"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -10,7 +10,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   #pull_request:
   # call from trivy_image_check.yaml, which in turn call from pull_request

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v1.0.51"
+  BASE_IMAGES_VERSION: "v1.1.2"
 on:
   push:
     tags:

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Download base images and auth prepare
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -82,7 +82,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -125,7 +125,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -168,7 +168,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4
@@ -211,7 +211,7 @@ jobs:
 
       - name: Download base images
         run: |
-          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
+          wget https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$BASE_IMAGES_VERSION/base_images.yml -O base_images.yml
           cat base_images.yml
 
       - uses: deckhouse/modules-actions/setup@v4

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -11,7 +11,7 @@ env:
   GOPROXY: ${{ secrets.GOPROXY }}
   SOURCE_REPO: ${{ secrets.SOURCE_REPO }}
   SOURCE_REPO_SSH_KEY: ${{ secrets.SOURCE_REPO_SSH_KEY }}
-  BASE_IMAGES_VERSION: "v0.5.79"
+  BASE_IMAGES_VERSION: "v1.0.51"
 on:
   push:
     tags:

--- a/.github/workflows/translate-changelog.yml
+++ b/.github/workflows/translate-changelog.yml
@@ -2,7 +2,7 @@ name: Translate Changelog and Create PR
 
 on:
   push:
-    # Запуск для всех веток при любом push
+    # Run for all branches on any push
 
 jobs:
   translate-and-pr:

--- a/.werf/base-images.yaml
+++ b/.werf/base-images.yaml
@@ -1,7 +1,7 @@
 # Base Images
 {{- $baseImages := .Files.Get "base_images.yml" | fromYaml }}
 {{- range $k, $v := $baseImages }}
-  {{ $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
+  {{- $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
   {{- if ne $k "REGISTRY_PATH" }}
     {{- $_ := set $baseImages $k $baseImagePath }}
   {{- end }}
@@ -9,11 +9,3 @@
 {{- $_ := unset $baseImages "REGISTRY_PATH" }}
 
 {{- $_ := set . "Images" $baseImages }}
-# base images artifacts
-{{- range $k, $v := .Images }}
----
-image: {{ $k }}
-from: {{ $v }}
-final: false
-{{- end }}
-

--- a/.werf/bundle.yaml
+++ b/.werf/bundle.yaml
@@ -1,6 +1,6 @@
 ---
 image: docs-generator
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 final: false
 
 git:
@@ -25,7 +25,7 @@ shell:
 # Bundle image, stored in your.registry.io/modules/<module-name>:<semver>
 ---
 image: bundle
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 
 import:
   # Rendering .werf/images-digests.yaml is required!

--- a/.werf/choose-edition.yaml
+++ b/.werf/choose-edition.yaml
@@ -1,6 +1,6 @@
 ---
 image: choose-edition
-fromImage: builder/alt
+from: {{ index $.Images "builder/golang-alt" }}
 fromCacheVersion: {{ div .Commit.Date.Unix (mul 60 60 24 30) }}
 
 git:

--- a/.werf/images-digests.yaml
+++ b/.werf/images-digests.yaml
@@ -13,9 +13,9 @@
 # Images Digest: a files with all image digests to be able to use them in helm templates of a module
 ---
 image: images-digests
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 import:
-  - image: tools/jq
+  - from: {{ index $.Images "jq" }}
     add: /usr/bin/jq
     to: /usr/bin/jq
     before: setup

--- a/.werf/images.yaml
+++ b/.werf/images.yaml
@@ -5,6 +5,7 @@
 {{- range $path, $content := $ImagesBuildFiles  }}
   {{- $ctx := dict }}
   {{- $_ := set $ctx "ImageName" ($path | split "/")._1 }}
+  {{- $_ := set $ctx "Images" $.Images }}
   {{- $_ := set $ctx "SOURCE_REPO" $Root.SOURCE_REPO }}
   {{- $_ := set $ctx "MODULE_EDITION" $.MODULE_EDITION }}
   {{- $_ := set $ctx "SVACE_ENABLED" (env "SVACE_ENABLED" "false") }}

--- a/.werf/release.yaml
+++ b/.werf/release.yaml
@@ -1,7 +1,7 @@
 # Release image, stored in your.registry.io/modules/<module-name>/release:<semver>
 ---
 image: release-channel-version-artifact
-fromImage: builder/alpine
+from: {{ index $.Images "builder/alpine" }}
 final: false
 git:
 - add: /
@@ -13,7 +13,7 @@ git:
     setup:
     - '**/*'
 import:
-  - image: tools/yq
+  - from: {{ index $.Images "yq" }}
     add: /usr/bin/yq
     to: /usr/bin/yq
     before: install
@@ -24,7 +24,7 @@ shell:
     - cp -f CHANGELOG/{{ env "MODULES_MODULE_TAG" "local" }}.yml /changelog.yaml || touch /changelog.yaml
 ---
 image: release-channel-version
-fromImage: builder/scratch
+from: {{ index $.Images "builder/scratch" }}
 import:
   - image: release-channel-version-artifact
     add: /

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@
 .PHONY: update-base-images-versions
 update-base-images-versions:
 	##~ Options: version=vMAJOR.MINOR.PATCH
-	curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml
+	curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml

--- a/images/controller/werf.inc.yaml
+++ b/images/controller/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -13,22 +13,22 @@ git:
       install:
         - '**/*'
     excludePaths:
-      - images/{{ $.ImageName }}/werf.yaml
+      - images/{{ $.ImageName }}/werf.inc.yaml
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src
     to: /src
-    before: install
+    before: setup
 
 mount:
 {{ include "mount points for golang builds" . }}
@@ -48,7 +48,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact

--- a/images/go-hooks/werf.inc.yaml
+++ b/images/go-hooks/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 git:
   - add: {{ .ModuleDir }}/hooks/go
@@ -20,18 +20,18 @@ git:
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src
     to: /usr/src/app
-    before: install
+    before: setup
 
 mount:
 {{ include "mount points for golang builds" . }}
@@ -41,7 +41,7 @@ secrets:
   value: {{ .GOPROXY }}
 
 shell:
-  install:
+  setup:
     - cd /usr/src/app/hooks/go
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0

--- a/images/sds-local-volume-csi/werf.inc.yaml
+++ b/images/sds-local-volume-csi/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -8,28 +8,28 @@ git:
     to: /src
     includePaths:
       - api
-      - lib/go      
+      - lib/go
       - images/{{ $.ImageName }}
     stageDependencies:
       install:
         - '**/*'
     excludePaths:
-      - images/{{ $.ImageName }}/werf.yaml
+      - images/{{ $.ImageName }}/werf.inc.yaml
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src
     to: /src
-    before: install
+    before: setup
 
 mount:
 {{ include "mount points for golang builds" . }}
@@ -49,7 +49,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 git:
 {{- include "image mount points" . }}
@@ -58,138 +58,17 @@ import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
     add: /{{ $.ImageName }}
     to: /{{ $.ImageName }}
-    before: install
-  - image: tools/e2fsprogs
-    add: /
-    to: /
-    before: install
-    includePaths:
-      - usr/sbin/badblocks
-      - usr/sbin/debugfs
-      - usr/sbin/dumpe2fs
-      - usr/sbin/e2freefrag
-      - usr/sbin/e2fsck
-      - usr/sbin/e2image
-      - usr/lib/e2initrd_helper
-      - usr/sbin/e2label
-      - usr/sbin/e2mmpstatus
-      - usr/sbin/e2scrub
-      - usr/sbin/e2scrub_all
-      - usr/sbin/e2undo
-      - usr/sbin/e4crypt
-      - usr/sbin/e4defrag
-      - usr/sbin/filefrag
-      - usr/sbin/fsck.ext2
-      - usr/sbin/fsck.ext3
-      - usr/sbin/fsck.ext4
-      - usr/sbin/logsave
-      - usr/sbin/mke2fs
-      - usr/sbin/mkfs.ext2
-      - usr/sbin/mkfs.ext3
-      - usr/sbin/mkfs.ext4
-      - usr/sbin/mklost+found
-      - usr/sbin/resize2fs
-      - usr/sbin/tune2fs
-      - usr/bin/chattr
-      - usr/bin/lsattr
-  - image: tools/xfsprogs
-    add: /
-    to: /
-    before: install
-    includePaths:
-      - usr/sbin/mkfs.xfs
-      - usr/sbin/xfs_admin
-      - usr/sbin/xfs_bmap
-      - usr/sbin/xfs_copy
-      - usr/sbin/xfs_db
-      - usr/sbin/xfs_estimate
-      - usr/sbin/xfs_freeze
-      - usr/sbin/xfs_fsr
-      - usr/sbin/xfs_growfs
-      - usr/sbin/xfs_info
-      - usr/sbin/xfs_io
-      - usr/sbin/xfs_logprint
-      - usr/sbin/xfs_mdrestore
-      - usr/sbin/xfs_metadump
-      - usr/sbin/xfs_mkfile
-      - usr/sbin/xfs_ncheck
-      - usr/sbin/xfs_property
-      - usr/sbin/xfs_quota
-      - usr/sbin/xfs_repair
-      - usr/sbin/xfs_rtcp
-      - usr/sbin/xfs_spaceman
-  - image: tools/lvm2
-    add: /
-    to: /
-    before: install
-    includePaths:
-      - usr/sbin/fsadm
-      - usr/sbin/lvchange
-      - usr/sbin/lvconvert
-      - usr/sbin/lvcreate
-      - usr/sbin/lvdisplay
-      - usr/sbin/lvextend
-      - usr/sbin/lvm
-      - usr/sbin/lvm_import_vdo
-      - usr/sbin/lvmconfig
-      - usr/sbin/lvmdevices
-      - usr/sbin/lvmdiskscan
-      - usr/sbin/lvmdump
-      - usr/sbin/lvmsadc
-      - usr/sbin/lvmsar
-      - usr/sbin/lvreduce
-      - usr/sbin/lvremove
-      - usr/sbin/lvrename
-      - usr/sbin/lvresize
-      - usr/sbin/lvs
-      - usr/sbin/lvscan
-      - usr/sbin/pvchange
-      - usr/sbin/pvck
-      - usr/sbin/pvcreate
-      - usr/sbin/pvdisplay
-      - usr/sbin/pvmove
-      - usr/sbin/pvremove
-      - usr/sbin/pvresize
-      - usr/sbin/pvs
-      - usr/sbin/pvscan
-      - usr/sbin/vgcfgbackup
-      - usr/sbin/vgcfgrestore
-      - usr/sbin/vgchange
-      - usr/sbin/vgck
-      - usr/sbin/vgconvert
-      - usr/sbin/vgcreate
-      - usr/sbin/vgdisplay
-      - usr/sbin/vgexport
-      - usr/sbin/vgextend
-      - usr/sbin/vgimport
-      - usr/sbin/vgimportclone
-      - usr/sbin/vgimportdevices
-      - usr/sbin/vgmerge
-      - usr/sbin/vgmknodes
-      - usr/sbin/vgreduce
-      - usr/sbin/vgremove
-      - usr/sbin/vgrename
-      - usr/sbin/vgs
-      - usr/sbin/vgscan
-      - usr/sbin/vgsplit
-  - image: tools/util-linux
-    add: /
-    to: /
     before: setup
-    includePaths:
-      - sbin/blkid
-      - sbin/blockdev
-      - bin/mount
-      - bin/umount
-      - sbin/swapon
-      - sbin/swapoff
-  - image: libs/glibc
-    add: /
-    to: /
-    before: setup    
-    includePaths:
-      - lib64/libnss_files.so.2
-      - lib64/libnss_dns.so.2
+
+shell:
+  setup:
+    - |
+      pm install \
+        gnu-glibc \
+        e2fsprogs \
+        xfsprogs \
+        lvm2 \
+        util-linux
 
 imageSpec:
   config:

--- a/images/webhooks/werf.inc.yaml
+++ b/images/webhooks/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
-fromImage: builder/src
+from: {{ index $.Images "builder/src" }}
 final: false
 
 git:
@@ -13,22 +13,22 @@ git:
       install:
         - '**/*'
     excludePaths:
-      - images/{{ $.ImageName }}/werf.yaml
+      - images/{{ $.ImageName }}/werf.inc.yaml
 
 shell:
   install:
-    - echo "src artifact"
+    - rm -rf /src/.git
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
-fromImage: {{ eq .SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
+from: {{ index $.Images (eq .SVACE_ENABLED "false" | ternary "builder/golang" "builder/alpine-svace") }}
 final: false
 
 import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-src-artifact
     add: /src
     to: /src
-    before: install
+    before: setup
 
 mount:
 {{ include "mount points for golang builds" . }}
@@ -48,7 +48,7 @@ shell:
 
 ---
 image: {{ .ModuleNamePrefix }}{{ .ImageName }}
-fromImage: base/distroless
+from: {{ index $.Images "builder/distroless" }}
 
 git:
 {{- include "image mount points" . }}
@@ -57,7 +57,7 @@ import:
   - image: {{ .ModuleNamePrefix }}{{ .ImageName }}-golang-artifact
     add: /{{ $.ImageName }}
     to: /{{ $.ImageName }}
-    before: install
+    before: setup
 
 imageSpec:
   config:


### PR DESCRIPTION
## Description

Migrate module build to `deckhouse/container-base/base-images` **v1.1.2**:

- Bump `BASE_IMAGES_VERSION` from `v0.5.79` to `v1.1.2` in dev/prod GitHub Actions workflows.
- Remove intermediate werf artifacts for base images; use `from: {{ index $.Images "…" }}` directly.
- Update all module images (`controller`, `webhooks`, `go-hooks`, `sds-local-volume-csi`) to `builder/golang`, `builder/alpine-svace`, `builder/distroless`, `builder/src`.
- Replace CSI runtime tool imports (`tools/e2fsprogs`, `tools/xfsprogs`, `tools/lvm2`, `tools/util-linux`, `libs/glibc`) with `pm install gnu-glibc e2fsprogs xfsprogs lvm2 util-linux` in the final CSI image.
- Add `no-cyrillic` dmtlint exclusion for `hack/`.

## Why do we need it, and what problem does it solve?

The module still used the legacy base-images werf pattern (`fromImage`, intermediate `tools/*` artifacts). Container-base provides distroless builder images and a package manager workflow (`pm install`) instead of copying binaries from pre-built tool images. Aligning with other storage modules simplifies maintenance and keeps base image versions in sync.

## What is the expected result?

- CI builds pull base images at `v1.1.2`.
- Module images build successfully with the new werf configuration.
- CSI node image retains required filesystem tools (e2fsprogs, xfsprogs, lvm2, util-linux, glibc NSS libs) via `pm install`.
- No functional changes to controller/webhooks logic; runtime behavior of the CSI driver should remain the same.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.