### PR TITLE
chore(module): replace snapshot-controller dependency with storage-foundation

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -7,5 +7,5 @@ requirements:
   deckhouse: ">= 1.72"
   modules:
     sds-node-configurator: ">= 0.6.1"
-    snapshot-controller: ">= 0.0.0"
+    storage-foundation: ">= 0.0.0"
 namespace: d8-sds-local-volume


### PR DESCRIPTION
## Description
Update the module requirements in `module.yaml`: replace the dependency on
`snapshot-controller` (`>= 0.0.0`) with a dependency on `storage-foundation`
(`>= 0.0.0`).

Snapshot-related functionality that `sds-local-volume` relies on now lives in
the `storage-foundation` module, so the requirement is pointed at the new
module accordingly.

## Why do we need it, and what problem does it solve?
The snapshot controller was moved into the `storage-foundation` module. Keeping
the requirement on `snapshot-controller` would reference a module that no longer
provides these capabilities, which could break dependency resolution and module
enablement. This change keeps `sds-local-volume`'s dependency graph correct.

## What is the expected result?
- `module.yaml` requires `storage-foundation: ">= 0.0.0"` instead of
  `snapshot-controller`.
- The module resolves and enables correctly when `storage-foundation` is present.
- No runtime behavior of `sds-local-volume` itself changes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.