### PR TITLE
Add VEX attestation

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -130,11 +130,13 @@ jobs:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
-      - uses: deckhouse/modules-actions/build@v4
+      - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.DEV_MODULE_SOURCE }}"
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ env.MODULES_MODULE_TAG }}
+          registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
           svace_enabled: ${{ contains(github.event.pull_request.labels.*.name, 'analyze/svace') || inputs.svace_enabled == true }}

--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -52,11 +52,13 @@ jobs:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
-      - uses: deckhouse/modules-actions/build@v4
+      - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/ce/modules"
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
@@ -95,11 +97,13 @@ jobs:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
-      - uses: deckhouse/modules-actions/build@v4
+      - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/ee/modules"
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
@@ -138,11 +142,13 @@ jobs:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
-      - uses: deckhouse/modules-actions/build@v4
+      - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/fe/modules"
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
@@ -181,11 +187,13 @@ jobs:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
-      - uses: deckhouse/modules-actions/build@v4
+      - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/se/modules"
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
@@ -224,11 +232,13 @@ jobs:
           registry: ${{ vars.DEV_REGISTRY }}
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
-      - uses: deckhouse/modules-actions/build@v4
+      - uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/se-plus/modules"
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.ref_name }}
+          registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
           secondary_repo: "${{ vars.DEV_MODULE_SOURCE }}/${{ vars.MODULE_NAME }}"
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -62,11 +62,13 @@ jobs:
           registry_login: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
       - if: ${{ github.event.inputs.enableBuild == 'true' }}
-        uses: deckhouse/modules-actions/build@v4
+        uses: deckhouse/modules-actions/build@v15
         with:
           module_source: "${{ vars.DEV_MODULE_SOURCE }}"
           module_name: ${{ vars.MODULE_NAME }}
           module_tag: ${{ github.event.inputs.tag }}
+          registry_user: ${{ vars.DEV_MODULES_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
           source_repo: ${{ secrets.SOURCE_REPO }}
           source_repo_ssh_key: ${{ secrets.SOURCE_REPO_SSH_KEY }}
       - uses: deckhouse/modules-actions/deploy@v4

--- a/.werf/base-images.yaml
+++ b/.werf/base-images.yaml
@@ -9,3 +9,14 @@
 {{- $_ := unset $baseImages "REGISTRY_PATH" }}
 
 {{- $_ := set . "Images" $baseImages }}
+---
+image: builder/distroless
+from: {{ index $.Images "builder/distroless" }}
+final: false
+---
+image: base/vex
+fromImage: builder/distroless
+final: false
+shell:
+  install:
+    - pm install coreutils ca-certificates cosign=2.6.3 jq curl bash

--- a/.werf/base-images.yaml
+++ b/.werf/base-images.yaml
@@ -10,12 +10,8 @@
 
 {{- $_ := set . "Images" $baseImages }}
 ---
-image: builder/distroless
-from: {{ index $.Images "builder/distroless" }}
-final: false
----
 image: base/vex
-fromImage: builder/distroless
+from: {{ index $.Images "builder/distroless" }}
 final: false
 shell:
   install:

--- a/.werf/defines/vex.tmpl
+++ b/.werf/defines/vex.tmpl
@@ -1,0 +1,143 @@
+# put image with vex mitigations to registry.
+# Mitigations can be found in the known_vulnerabilities.vex file in the image directory
+# input parameters:
+# list of $ and image name.
+# list ($ "common/kubernetes")
+{{- define "vex mitigation" }}
+  {{- $context := index . 0 }}
+  {{- $imageName := index . 1 }}
+  {{- $knownVulnPath := "" }}
+  {{- $isVault := false }}
+  {{- if eq $imageName "dev" }}
+    {{- $knownVulnPath = "/deckhouse-controller/known_vulnerabilities.vex" }}
+  {{- else if eq $imageName "dev/install" }}
+    {{- $knownVulnPath = "/dhctl/known_vulnerabilities.vex" }}
+  {{- else if eq $imageName "bundle" }}
+    {{- $knownVulnPath = "/known_vulnerabilities.vex" }}
+  {{- else if hasKey $context "ModulePriority" }}
+    {{- $knownVulnPath = (printf "/%smodules/%s-%s/images/%s/known_vulnerabilities.vex" $context.ModulePath $context.ModulePriority $context.ModuleName $context.ImageName) }}
+  {{- else }}
+    {{- $knownVulnPath = (printf "/images/%s/known_vulnerabilities.vex" $context.ImageName) }}
+  {{- end }}
+  {{- $vexFile := false }}
+  {{- if eq (len ($context.Files.Glob $knownVulnPath)) 1 }}
+    {{- $vexFile = true }}
+  {{- end }}
+  {{- $werfSignKey := env "WERF_SIGN_KEY" "" }}
+  {{- $vaultKey := env "VAULT_KEY" "" }}
+  {{- $actionsIdToken := env "ACTIONS_ID_TOKEN_REQUEST_TOKEN" "" }}
+  {{- if or (ne $werfSignKey "") (ne $vaultKey "") (ne $actionsIdToken "") }}
+    {{- $isVault = true }}
+  {{- end }}
+  {{- if $vexFile }}
+---
+image: {{ $imageName }}-vex-artifact
+fromImage: base/vex
+final: true
+secrets:
+- id: REGISTRY_USER
+  env: REGISTRY_USER
+- id: REGISTRY_PASSWORD
+  env: REGISTRY_PASSWORD
+{{- if eq $isVault true }}
+{{- if ne $werfSignKey "" }}
+- id: VAULT_ADDR
+  env: VAULT_ADDR
+- id: VAULT_KEY
+  env: WERF_SIGN_KEY
+- id: VAULT_ROLE
+  env: WERF_VAULT_AUTH_ROLE
+- id: VAULT_JWT
+  env: WERF_VAULT_AUTH_JWT
+- id: TRANSIT_SECRET_ENGINE_PATH
+  env: TRANSIT_SECRET_ENGINE_PATH
+{{- else }}
+- id: VAULT_ADDR
+  env: VAULT_ADDR
+- id: VAULT_KEY
+  env: VAULT_KEY
+- id: VAULT_ROLE
+  env: VAULT_ROLE
+- id: TRANSIT_SECRET_ENGINE_PATH
+  env: TRANSIT_SECRET_ENGINE_PATH
+{{- if eq $actionsIdToken "" }}
+- id: VAULT_JWT
+  env: VAULT_ID_TOKEN
+{{- end }}
+{{- end }}
+{{- if ne $actionsIdToken "" }}
+- id: ACTIONS_ID_TOKEN_REQUEST_TOKEN
+  env: ACTIONS_ID_TOKEN_REQUEST_TOKEN
+- id: ACTIONS_ID_TOKEN_REQUEST_URL
+  env: ACTIONS_ID_TOKEN_REQUEST_URL
+{{- end }}
+{{- end }}
+git:
+- add: {{ $knownVulnPath }}
+  to: /known_vulnerabilities.vex
+  stageDependencies:
+    install:
+    - "**/*"
+dependencies:
+- image: {{ $imageName }}
+  before: install
+  imports:
+  - type: ImageDigest
+    targetEnv: IMAGE_DIGEST
+  - type: ImageRepo
+    targetEnv: IMAGE_REPO
+shell:
+  install:
+  - export REGISTRY_USER="$(cat /run/secrets/REGISTRY_USER)"
+  - export REGISTRY_PASSWORD="$(cat /run/secrets/REGISTRY_PASSWORD)"
+{{- if $isVault }}
+  - export VAULT_ADDR="$(cat /run/secrets/VAULT_ADDR)"
+  - export VAULT_ROLE="$(cat /run/secrets/VAULT_ROLE)"
+  - export TRANSIT_SECRET_ENGINE_PATH="$(cat /run/secrets/TRANSIT_SECRET_ENGINE_PATH)"
+  - VAULT_KEY=$(cat /run/secrets/VAULT_KEY)
+  - export VAULT_KEY="hashivault://${VAULT_KEY#hashivault://}"
+{{- if ne $actionsIdToken "" }}
+  - export ACTIONS_ID_TOKEN_REQUEST_TOKEN="$(cat /run/secrets/ACTIONS_ID_TOKEN_REQUEST_TOKEN)"
+  - export ACTIONS_ID_TOKEN_REQUEST_URL="$(cat /run/secrets/ACTIONS_ID_TOKEN_REQUEST_URL)"
+  - export VAULT_AUTH_PATH="github"
+  - >
+    export VAULT_JWT=$(jq -r .value <<< $(curl -fsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+  - >
+    if [ -n "${VAULT_JWT}" ]; then
+      echo "Received Actions token";
+    else
+      echo "Actions token empty";
+    fi
+{{- else }}
+  - export VAULT_AUTH_PATH="fox"
+  - export VAULT_JWT="$(cat /run/secrets/VAULT_JWT)"
+{{- end }}
+  - >
+    export VAULT_TOKEN="$(curl -fX POST "${VAULT_ADDR}/v1/auth/${VAULT_AUTH_PATH}/login" -d '{"role":"'${VAULT_ROLE}'","jwt":"'${VAULT_JWT}'"}' | jq -r '.auth.client_token')"
+  - >
+    if [ -n "${VAULT_TOKEN}" ]; then
+      echo "Received Vault token";
+    else
+      echo "Vault token empty";
+    fi
+  - echo "Using predicate known_vulnerabilities.vex"
+{{- else }}
+  - |
+    echo -e "\033[33mWARNING!!! Cosign will sign attestation with self-generated key pair!\033[0m"
+    export COSIGN_PASSWORD=""
+    cosign generate-key-pair
+    export VAULT_KEY="cosign.key"
+{{- end }}
+  - |
+    cosign attest \
+      --replace \
+      --registry-username="${REGISTRY_USER}" \
+      --registry-password="${REGISTRY_PASSWORD}" \
+      --predicate /known_vulnerabilities.vex \
+      --type openvex \
+      --key ${VAULT_KEY} \
+      --tlog-upload=false \
+      -y -d \
+      "${IMAGE_REPO}@${IMAGE_DIGEST}"
+  {{- end }}
+{{- end }}

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -12,6 +12,9 @@ config:
       - SVACE_ENABLED
       - SVACE_ANALYZE_HOST
       - SVACE_ANALYZE_SSH_USER
+      - ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      - VAULT_KEY
+      - WERF_SIGN_KEY
     allowUncommittedFiles:
       - "base_images.yml"
   secrets:
@@ -19,6 +22,16 @@ config:
       - GOPROXY
       - SOURCE_REPO
       - DISTRO_PACKAGES_PROXY
+    allowEnvVariables:
+      - REGISTRY_USER
+      - REGISTRY_PASSWORD
+      - VAULT_ADDR
+      - WERF_SIGN_KEY
+      - WERF_VAULT_AUTH_ROLE
+      - WERF_VAULT_AUTH_JWT
+      - TRANSIT_SECRET_ENGINE_PATH
+      - ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      - ACTIONS_ID_TOKEN_REQUEST_URL
   stapel:
     mount:
       allowBuildDir: true


### PR DESCRIPTION
## Description
- Add `.werf/defines/vex.tmpl` (define `vex mitigation`, cosign OpenVEX) — copied as-is; werf auto-loads `.werf/**/*.tmpl`, so no `werf.yaml` include is needed for it.
- Add the `base/vex` image via `pm install` (`cosign=2.6.3`) in `.werf/base-images.yaml`.
- Extend `werf-giterminism.yaml` with signing-mode env vars and registry/Vault secrets for CSE compatibility.
- CI: bump `modules-actions/build` to `v15` and pass registry credentials.
- Infra-only: no `known_vulnerabilities.vex` files exist yet, so no per-image `vex mitigation` include is wired; attestation activates automatically once VEX files are added.

Build-time / CI-only changes; no cluster components are affected (no restarts of control-plane, ingress-controllers, Prometheus, etc.).

## Why do we need it, and what problem does it solve?
Signed OpenVEX attestations let a module publish assessed, non-actionable CVEs (`known_vulnerabilities.vex`) alongside its images. CVE gates / DefectDojo consume these attestations and drop already-triaged findings from the vulnerability report instead of failing the pipeline on them. This standardises VEX support across all storage modules.

## What is the expected result?
- Build behaviour is unchanged for now: no `known_vulnerabilities.vex` files exist, so no `*-vex-artifact` is produced and nothing is attested.
- Once a `known_vulnerabilities.vex` is added under `images/<name>/` and the `vex mitigation` include is wired, `werf build` produces a signed `<image>-vex-artifact`.
- Build MUST NOT fail when a `known_vulnerabilities.vex` is absent.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.