### PR TITLE
Add E2E CI pipeline

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,36 @@
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copy of deckhouse/storage-e2e/.github/templates/e2e-tests.yml with module inputs adjusted.
+# Required: PR labels e2e/run, e2e/keep-cluster, e2e/label:* and the inherited
+# org/repo secrets (see storage-e2e README "Enabling e2e in your module").
+
+name: E2E
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  e2e:
+    # Heavy e2e runs only when the PR carries the e2e/run label.
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'e2e/run') }}
+    uses: deckhouse/storage-e2e/.github/workflows/e2e.yml@main
+    with:
+      module_slug: ${{ vars.MODULE_NAME }}
+      module_path: e2e
+      test_package: ./tests/
+      cluster_config: e2e/tests/cluster_config.yml
+      module_image_tag: pr${{ github.event.pull_request.number }}
+    secrets: inherit


### PR DESCRIPTION
## Description

Add a standalone E2E CI workflow for `sds-local-volume`, following the storage-e2e consumer template and the same approach as [deckhouse/snapshot-controller#98](https://github.com/deckhouse/snapshot-controller/pull/98).

**New file:** `.github/workflows/e2e-tests.yml`

* Calls `deckhouse/storage-e2e/.github/workflows/e2e.yml@main` with module-specific inputs (`e2e/`, `e2e/tests/cluster_config.yml`, `module_image_tag: pr<N>`).
* Runs only when the PR has the **`e2e/run`** label.
* Does **not** modify `build_dev.yml`, `trivy_image_check.yaml`, or the default `Build and checks` pipeline.

No cluster runtime behaviour changes — CI wiring only.

## Why do we need it, and what problem does it solve?

Storage modules are standardizing on the shared **storage-e2e** reusable workflow (`bootstrap` → `run-tests` → `teardown`) instead of per-module bespoke E2E pipelines.

This PR adds a thin, label-gated caller workflow so E2E can be enabled on demand once the `e2e/` test suite lands, without coupling it to every PR build/CVE run.

## What is the expected result?

After merge:

* Regular PR CI (`Build and checks`, CVE scan) is **unchanged** — no E2E jobs unless the label is applied.
* Adding **`e2e/run`** to a PR triggers the **E2E** workflow:
  1. Bootstrap nested cluster (via storage-e2e, `cluster_provider: dvp` by default);
  2. Run `go test` in `e2e/tests/` against image tag `pr<N>` from dev CI;
  3. Teardown (unless `e2e/keep-cluster` is set).
* Until `e2e/` tests and `e2e/tests/cluster_config.yml` exist, the E2E workflow will fail if triggered — that is expected.

### Repository setup required for E2E to work

The workflow uses `secrets: inherit`. Below is what must exist in the **sds-local-volume** repo (or org) before the first labelled run.

#### PR labels

| Label | Required | Purpose |
| --- | --- | --- |
| `e2e/run` | Yes | Gate — without it the E2E workflow does not run |
| `e2e/keep-cluster` | No | Skip teardown; reuse the same cluster on re-runs |
| `e2e/label:<suite>` | No | Ginkgo label filter (e.g. `e2e/label:stress-test`); multiple labels are OR-ed |

#### Repository secrets — DVP provider (default)

Used by `cluster_provider: dvp` (the default in `e2e.yml`).

| Secret | Required | Purpose |
| --- | --- | --- |
| `E2E_DVP_BASE_CLUSTER_SSH_PRIVATE_KEY` | **Yes** | SSH private key content for the base virtualization cluster |
| `E2E_DVP_BASE_CLUSTER_KUBECONFIG` | **Yes** | Base64-encoded kubeconfig of the base cluster |
| `E2E_DVP_BASE_CLUSTER_SSH_USER` | **Yes** | SSH user on the base cluster |
| `E2E_DVP_BASE_CLUSTER_SSH_HOST` | **Yes** | SSH host of the base cluster |
| `E2E_DVP_DKP_LICENSE_KEY` | **Yes** | DKP license token for nested cluster bootstrap |
| `E2E_DVP_REGISTRY_DOCKER_CFG` | **Yes** | Base64 docker config for the Deckhouse dev registry |
| `E2E_DVP_BASE_CLUSTER_SSH_PASSPHRASE` | No | SSH key passphrase (if the key is encrypted) |
| `E2E_DVP_BASE_CLUSTER_STORAGE_CLASS` | No | StorageClass for VirtualDisks on the base cluster |
| `GOPROXY` | No | Go module proxy (likely already set for build workflows) |

Jump-host secrets (`E2E_DVP_BASE_CLUSTER_SSH_JUMP_*`) are optional and currently not wired in the workflow — CI connects directly.

#### Repository secrets — Commander provider (only if switching provider)

Not needed with the current workflow (default `dvp`). Required if `cluster_provider: commander` is enabled later:

| Secret / variable | Required | Purpose |
| --- | --- | --- |
| `E2E_COMMANDER_URL` | Yes | Commander API URL |
| `E2E_COMMANDER_TOKEN` | Yes | Commander API token |
| `E2E_COMMANDER_TEMPLATE_NAME` | Yes | Cluster template name |
| `E2E_COMMANDER_CA_CERT` | No | CA cert for Commander TLS |
| `E2E_COMMANDER_TEMPLATE_VERSION` (var) | No | Pin template version |
| `E2E_COMMANDER_REGISTRY_NAME` (var) | No | Registry name for cluster creation |
| Other `E2E_COMMANDER_*` vars | No | See [storage-e2e CI docs](https://github.com/deckhouse/storage-e2e/blob/main/docs/CI.md) |

#### Repository variables

| Variable | Required | Purpose |
| --- | --- | --- |
| `MODULE_NAME` | **Yes** | Module slug (`sds-local-volume`); used as `module_slug` and in the E2E namespace |
| `E2E_LOG_LEVEL` | No | Log level for storage-e2e bootstrap/tests (`info` by default) |

Full reference: [storage-e2e docs/CI.md](https://github.com/deckhouse/storage-e2e/blob/main/docs/CI.md).

## Checklist

- [ ] The code is covered by unit tests. _(N/A — CI workflow only)_
- [ ] e2e tests passed. _(N/A — `e2e/` suite not added yet; pipeline is label-gated and ready)_
- [ ] Documentation updated according to the changes. _(N/A — no contract change)_
- [ ] Changes were tested in the Kubernetes cluster manually. _(N/A — pipeline wiring only; cluster run is label-gated)_
