### PR TITLE
fix(csi): align plain-create volume size to the LVM extent

### DIFF
--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -40,6 +40,62 @@ const (
 	LVMVolumeCleanupParamKey = "local.csi.storage.deckhouse.io/lvm-volume-cleanup"
 )
 
+// alignToLVGExtentOrStatusErr rounds size up to the extent boundary of the given
+// LVG. The node always provisions whole extents, so every size that ends up in
+// LVMLogicalVolume.Spec.Size or in a response capacity has to go through this
+// first, otherwise it drifts from the LV that actually exists.
+//
+// The returned error is already a gRPC status and is meant to be handed straight
+// back to the caller of the RPC.
+func (d *Driver) alignToLVGExtentOrStatusErr(traceID, volumeID string, size resource.Quantity, lvg *v1alpha1.LVMVolumeGroup) (resource.Quantity, error) {
+	aligned, err := utils.AlignSizeToExtent(size, utils.SafeExtentSize(lvg.Status.ExtentSize))
+	if err != nil {
+		d.log.Error(err, fmt.Sprintf("[traceID:%s][volumeID:%s] error aligning size to extent", traceID, volumeID))
+		return resource.Quantity{}, status.Errorf(codes.Internal, "error aligning size to extent: %s", err.Error())
+	}
+
+	return aligned, nil
+}
+
+// fitsFreeSpace reports whether an extent-aligned request fits into the free
+// space of the node picked by Immediate binding.
+//
+// Only thick volumes are checked: a thin volume is over-provisioned by design,
+// and with WaitForFirstConsumer the node is chosen by the scheduler, which has
+// already accounted for the space.
+//
+// The check is deliberately performed on the aligned size: a request that fits
+// only before rounding would pass here and then fail on the node with a far less
+// obvious "not enough space", after CreateVolume had already blocked waiting for
+// the LV.
+func fitsFreeSpace(bindingMode, lvmType string, alignedSize, freeSpace resource.Quantity) bool {
+	if bindingMode != internal.BindingModeI || lvmType != internal.LVMTypeThick {
+		return true
+	}
+
+	return alignedSize.Value() <= freeSpace.Value()
+}
+
+// resolveCapacityBytes returns the capacity to report for a created or resized
+// volume: the size that actually exists on the node rather than the size that
+// was asked for.
+//
+// The node provisions whole extents, and on the content-source paths the size
+// may have been derived from a source whose Spec.Size predates extent alignment,
+// so the requested value is not what the caller ends up with.
+//
+// llv is expected to carry a status — WaitForStatusUpdate only returns once it
+// does — but the fallback keeps a nil status from turning into a panic inside a
+// gRPC handler. The second return value reports whether the status was present,
+// so callers can log the anomaly.
+func resolveCapacityBytes(llv *v1alpha1.LVMLogicalVolume, fallback resource.Quantity) (int64, bool) {
+	if llv != nil && llv.Status != nil {
+		return llv.Status.ActualSize.Value(), true
+	}
+
+	return fallback.Value(), false
+}
+
 func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	traceID := uuid.New().String()
 
@@ -98,6 +154,17 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 	var sourceVolume *v1alpha1.LVMLogicalVolumeSource
 
 	if request.VolumeContentSource != nil {
+		// The node clones and restores with `lvcreate -s`, which exists for thin
+		// volumes only. A Thick LVMLogicalVolume carrying a Source is created by the
+		// agent as an empty LV and the source is silently ignored, so the user would
+		// end up with a Bound PVC holding no data. Reject the combination here to
+		// turn that into a synchronous error.
+		if LvmType != internal.LVMTypeThin {
+			err := fmt.Errorf("volume content source is supported for %s volumes only, got %s", internal.LVMTypeThin, LvmType)
+			d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] unsupported LvmType for a volume with a content source", traceID, volumeID))
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
 		sourceVolume = &v1alpha1.LVMLogicalVolumeSource{}
 		switch s := request.VolumeContentSource.Type.(type) {
 		case *csi.VolumeContentSource_Snapshot:
@@ -137,10 +204,9 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 			if llvSize.Value() == 0 {
 				*llvSize = sourceVol.Status.Size
 			} else {
-				alignedLlvSize, alignErr := utils.AlignSizeToExtent(*llvSize, utils.SafeExtentSize(selectedLVG.Status.ExtentSize))
+				alignedLlvSize, alignErr := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *llvSize, selectedLVG)
 				if alignErr != nil {
-					d.log.Error(alignErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error aligning size to extent", traceID, volumeID))
-					return nil, status.Errorf(codes.Internal, "error aligning size to extent: %s", alignErr.Error())
+					return nil, alignErr
 				}
 				*llvSize = alignedLlvSize
 				if llvSize.Value() < sourceVol.Status.Size.Value() {
@@ -183,10 +249,9 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 			if llvSize.Value() == 0 {
 				*llvSize = sourceSizeQty
 			} else {
-				alignedLlvSize, alignErr := utils.AlignSizeToExtent(*llvSize, utils.SafeExtentSize(selectedLVG.Status.ExtentSize))
+				alignedLlvSize, alignErr := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *llvSize, selectedLVG)
 				if alignErr != nil {
-					d.log.Error(alignErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error aligning size to extent", traceID, volumeID))
-					return nil, status.Errorf(codes.Internal, "error aligning size to extent: %s", alignErr.Error())
+					return nil, alignErr
 				}
 				*llvSize = alignedLlvSize
 				if llvSize.Value() < sourceSizeQty.Value() {
@@ -197,21 +262,23 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 			preferredNode = selectedLVG.Spec.Local.NodeName
 		}
 	} else {
+		// Free space of the node picked by Immediate binding. The thick check against
+		// it is deferred until after the size has been aligned below, because the node
+		// provisions whole extents and it is the aligned size that has to fit.
+		var maxFreeSpace resource.Quantity
+
 		switch BindingMode {
 		case internal.BindingModeI:
 			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] BindingMode is %s. Start selecting node", traceID, volumeID, internal.BindingModeI))
 			selectedNodeName, freeSpace, err := utils.GetNodeWithMaxFreeSpace(storageClassLVGs, storageClassLVGParametersMap, LvmType)
 			if err != nil {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error GetNodeMaxVGSize", traceID, volumeID))
+				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error GetNodeWithMaxFreeSpace", traceID, volumeID))
+				return nil, status.Errorf(codes.Internal, "error selecting the node with max free space: %s", err.Error())
 			}
 
 			preferredNode = selectedNodeName
+			maxFreeSpace = freeSpace
 			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] Selected node: %s, free space %s", traceID, volumeID, selectedNodeName, freeSpace.String()))
-			if LvmType == internal.LVMTypeThick {
-				if llvSize.Value() > freeSpace.Value() {
-					return nil, status.Errorf(codes.Internal, "requested size: %s is greater than free space: %s", llvSize.String(), freeSpace.String())
-				}
-			}
 		case internal.BindingModeWFFC:
 			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] BindingMode is %s. Get preferredNode", traceID, volumeID, internal.BindingModeWFFC))
 			if len(request.AccessibilityRequirements.Preferred) != 0 {
@@ -226,6 +293,21 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		if err != nil {
 			d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error SelectLVG", traceID, volumeID))
 			return nil, status.Errorf(codes.Internal, "error during SelectLVG")
+		}
+
+		// Align the requested size to the LVM extent boundary so that Spec.Size and
+		// the reported capacity match the size the node actually provisions. The
+		// snapshot/volume content-source branches above already align; without this
+		// the plain path stores an unaligned size (e.g. 35Mi) that drifts from the
+		// extent-rounded LV on the node.
+		alignedLlvSize, alignErr := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *llvSize, selectedLVG)
+		if alignErr != nil {
+			return nil, alignErr
+		}
+		*llvSize = alignedLlvSize
+
+		if !fitsFreeSpace(BindingMode, LvmType, *llvSize, maxFreeSpace) {
+			return nil, status.Errorf(codes.Internal, "requested size: %s is greater than free space: %s", llvSize.String(), maxFreeSpace.String())
 		}
 	}
 
@@ -262,7 +344,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] start wait CreateLVMLogicalVolume", traceID, volumeID))
 
-	attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, d.log, traceID, request.Name, "", *llvSize, utils.SafeExtentSize(selectedLVG.Status.ExtentSize))
+	createdLLV, attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, d.log, traceID, request.Name, "", *llvSize, utils.SafeExtentSize(selectedLVG.Status.ExtentSize))
 	if err != nil {
 		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error WaitForStatusUpdate. Delete LVMLogicalVolume %s", traceID, volumeID, request.Name))
 
@@ -275,6 +357,11 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		return nil, err
 	}
 	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] finish wait CreateLVMLogicalVolume, attempt counter = %d", traceID, volumeID, attemptCounter))
+
+	capacityBytes, fromStatus := resolveCapacityBytes(createdLLV, *llvSize)
+	if !fromStatus {
+		d.log.Warning(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] LVMLogicalVolume %s has no status after a successful wait, reporting the aligned requested size %s", traceID, volumeID, request.Name, llvSize.String()))
+	}
 
 	volumeCtx := make(map[string]string, len(request.Parameters))
 	for k, v := range request.Parameters {
@@ -293,7 +380,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			CapacityBytes: request.CapacityRange.GetRequiredBytes(),
+			CapacityBytes: capacityBytes,
 			VolumeId:      request.Name,
 			VolumeContext: volumeCtx,
 			ContentSource: request.VolumeContentSource,
@@ -433,10 +520,9 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.Contro
 	requestCapacity := resource.NewQuantity(request.CapacityRange.GetRequiredBytes(), resource.BinarySI)
 	d.log.Trace(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] requestCapacity: %s", traceID, volumeID, requestCapacity.String()))
 
-	alignedRequestCapacity, err := utils.AlignSizeToExtent(*requestCapacity, utils.SafeExtentSize(lvg.Status.ExtentSize))
+	alignedRequestCapacity, err := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *requestCapacity, lvg)
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] error aligning size to extent", traceID, volumeID))
-		return nil, status.Errorf(codes.Internal, "error aligning size to extent: %s", err.Error())
+		return nil, err
 	}
 
 	nodeExpansionRequired := request.GetVolumeCapability().GetBlock() == nil
@@ -467,23 +553,22 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.Contro
 		return nil, status.Errorf(codes.Internal, "error updating LVMLogicalVolume: %v", err)
 	}
 
-	attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, d.log, traceID, llv.Name, llv.Namespace, *requestCapacity, utils.SafeExtentSize(lvg.Status.ExtentSize))
+	updatedLLV, attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, d.log, traceID, llv.Name, llv.Namespace, *requestCapacity, utils.SafeExtentSize(lvg.Status.ExtentSize))
 	if err != nil {
 		d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] error WaitForStatusUpdate", traceID, volumeID))
 		return nil, err
 	}
 	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] finish resize LVMLogicalVolume, attempt counter = %d ", traceID, volumeID, attemptCounter))
 
-	updatedLLV, err := utils.GetLVMLogicalVolume(ctx, d.cl, llv.Name, llv.Namespace)
-	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] error re-fetching LVMLogicalVolume after resize", traceID, volumeID))
-		return nil, status.Errorf(codes.Internal, "error re-fetching LVMLogicalVolume after resize: %v", err)
+	capacityBytes, fromStatus := resolveCapacityBytes(updatedLLV, alignedRequestCapacity)
+	if !fromStatus {
+		d.log.Warning(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] LVMLogicalVolume %s has no status after a successful wait, reporting the aligned requested size %s", traceID, volumeID, llv.Name, alignedRequestCapacity.String()))
 	}
 
 	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] Volume expanded successfully", traceID, volumeID))
 
 	return &csi.ControllerExpandVolumeResponse{
-		CapacityBytes:         updatedLLV.Status.ActualSize.Value(),
+		CapacityBytes:         capacityBytes,
 		NodeExpansionRequired: nodeExpansionRequired,
 	}, nil
 }

--- a/images/sds-local-volume-csi/driver/controller_snapshots_ee.go
+++ b/images/sds-local-volume-csi/driver/controller_snapshots_ee.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/internal"
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/pkg/utils"
@@ -120,17 +119,19 @@ func (d *Driver) CreateSnapshot(ctx context.Context, request *csi.CreateSnapshot
 	}
 	d.log.Trace(fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] finish wait CreateLVMLogicalVolume, attempt counter = %d", traceID, name, attemptCounter))
 
-	sourceSizeQty, err := resource.ParseQuantity(llv.Spec.Size)
-	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[CreateSnapshot][traceID:%s] error parsing quantity %s", traceID, llv.Spec.Size))
-		return nil, status.Errorf(codes.Internal, "error parsing quantity: %v", err)
-	}
+	// Reported from the status, not from Spec.Size: the node rounds the LV up to the
+	// extent boundary, and volumes provisioned before the CSI side started aligning
+	// still carry an unaligned Spec.Size (e.g. 35Mi against a 36Mi LV). Restoring
+	// such a snapshot would then ask for a size the source does not have. The
+	// precondition at the top of this function already guarantees a non-zero
+	// ActualSize, and the free-space check above is made against the same value.
+	sizeBytes := llv.Status.ActualSize.Value()
 
 	return &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{
 			SnapshotId:     name,
 			SourceVolumeId: request.SourceVolumeId,
-			SizeBytes:      sourceSizeQty.Value(),
+			SizeBytes:      sizeBytes,
 			CreationTime: &timestamp.Timestamp{
 				Seconds: time.Now().Unix(),
 				Nanos:   0,

--- a/images/sds-local-volume-csi/driver/controller_test.go
+++ b/images/sds-local-volume-csi/driver/controller_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/internal"
+	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
+)
+
+func TestFitsFreeSpace(t *testing.T) {
+	tests := []struct {
+		name        string
+		bindingMode string
+		lvmType     string
+		alignedSize string
+		freeSpace   string
+		want        bool
+	}{
+		{
+			// The case the check was moved for: 35Mi fits, but the node provisions
+			// whole 4Mi extents and 36Mi does not. Before the move the raw request
+			// passed here and failed on the node with "not enough space", after
+			// CreateVolume had already blocked waiting for the LV.
+			name:        "aligned_thick_request_no_longer_fits_after_rounding",
+			bindingMode: internal.BindingModeI,
+			lvmType:     internal.LVMTypeThick,
+			alignedSize: "36Mi",
+			freeSpace:   "35Mi",
+			want:        false,
+		},
+		{
+			name:        "thick_request_fits",
+			bindingMode: internal.BindingModeI,
+			lvmType:     internal.LVMTypeThick,
+			alignedSize: "36Mi",
+			freeSpace:   "1Gi",
+			want:        true,
+		},
+		{
+			name:        "thick_request_exactly_fills_free_space",
+			bindingMode: internal.BindingModeI,
+			lvmType:     internal.LVMTypeThick,
+			alignedSize: "36Mi",
+			freeSpace:   "36Mi",
+			want:        true,
+		},
+		{
+			// Thin volumes are over-provisioned by design, the pool is allowed to be
+			// smaller than the sum of its volumes.
+			name:        "thin_request_is_not_checked",
+			bindingMode: internal.BindingModeI,
+			lvmType:     internal.LVMTypeThin,
+			alignedSize: "1Ti",
+			freeSpace:   "1Mi",
+			want:        true,
+		},
+		{
+			// With WaitForFirstConsumer the node is picked by the scheduler, which has
+			// already accounted for the space; maxFreeSpace is not even collected.
+			name:        "wffc_thick_request_is_not_checked_here",
+			bindingMode: internal.BindingModeWFFC,
+			lvmType:     internal.LVMTypeThick,
+			alignedSize: "36Mi",
+			freeSpace:   "0",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fitsFreeSpace(
+				tt.bindingMode,
+				tt.lvmType,
+				resource.MustParse(tt.alignedSize),
+				resource.MustParse(tt.freeSpace),
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveCapacityBytes(t *testing.T) {
+	fallback := resource.MustParse("36Mi")
+
+	t.Run("reports_the_size_that_exists_on_the_node", func(t *testing.T) {
+		// A volume restored from a 36Mi source but requested at 52Mi ends up at 52Mi
+		// on the node; a plain 35Mi request ends up at 36Mi. Either way the status is
+		// the only value that describes the LV that was actually created.
+		llv := &v1alpha1.LVMLogicalVolume{
+			Status: &v1alpha1.LVMLogicalVolumeStatus{
+				ActualSize: resource.MustParse("52Mi"),
+			},
+		}
+
+		expected := resource.MustParse("52Mi")
+
+		got, fromStatus := resolveCapacityBytes(llv, fallback)
+		assert.True(t, fromStatus)
+		assert.Equal(t, expected.Value(), got)
+	})
+
+	t.Run("falls_back_to_the_aligned_request_when_status_is_missing", func(t *testing.T) {
+		got, fromStatus := resolveCapacityBytes(&v1alpha1.LVMLogicalVolume{}, fallback)
+		assert.False(t, fromStatus)
+		assert.Equal(t, fallback.Value(), got)
+	})
+
+	t.Run("falls_back_when_the_resource_itself_is_missing", func(t *testing.T) {
+		got, fromStatus := resolveCapacityBytes(nil, fallback)
+		assert.False(t, fromStatus)
+		assert.Equal(t, fallback.Value(), got)
+	})
+}

--- a/images/sds-local-volume-csi/pkg/utils/func.go
+++ b/images/sds-local-volume-csi/pkg/utils/func.go
@@ -295,13 +295,18 @@ func DeleteLVMLogicalVolume(ctx context.Context, kc client.Client, log *logger.L
 	return err
 }
 
-func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logger, traceID, lvmLogicalVolumeName, namespace string, llvSize, extentSize resource.Quantity) (int, error) {
+// WaitForStatusUpdate polls the LVMLogicalVolume until the node agent reports it
+// Created with an ActualSize that covers the extent-aligned llvSize, and returns
+// that very object. Callers need the resulting size, so returning the resource
+// they waited for saves them a second GET and closes the window in which the
+// status could change between the wait and the re-read.
+func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logger, traceID, lvmLogicalVolumeName, namespace string, llvSize, extentSize resource.Quantity) (*snc.LVMLogicalVolume, int, error) {
 	var attemptCounter int
 	log.Info(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Waiting for LVM Logical Volume status update", traceID, lvmLogicalVolumeName))
 
 	alignedSize, err := AlignSizeToExtent(llvSize, extentSize)
 	if err != nil {
-		return 0, fmt.Errorf("unable to align size: %w", err)
+		return nil, 0, fmt.Errorf("unable to align size: %w", err)
 	}
 
 	for {
@@ -309,14 +314,14 @@ func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logg
 		select {
 		case <-ctx.Done():
 			log.Warning(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] context done. Failed to wait for LVM Logical Volume status update", traceID, lvmLogicalVolumeName))
-			return attemptCounter, ctx.Err()
+			return nil, attemptCounter, ctx.Err()
 		default:
 			time.Sleep(500 * time.Millisecond)
 		}
 
 		llv, err := GetLVMLogicalVolume(ctx, kc, lvmLogicalVolumeName, namespace)
 		if err != nil {
-			return attemptCounter, err
+			return nil, attemptCounter, err
 		}
 
 		if attemptCounter%10 == 0 {
@@ -327,16 +332,16 @@ func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logg
 			log.Trace(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume status: %+v, full LVMLogicalVolume resource: %+v", traceID, lvmLogicalVolumeName, attemptCounter, llv.Status, llv))
 
 			if llv.DeletionTimestamp != nil {
-				return attemptCounter, fmt.Errorf("failed to create LVM logical volume on node for LVMLogicalVolume %s, reason: LVMLogicalVolume is being deleted", lvmLogicalVolumeName)
+				return nil, attemptCounter, fmt.Errorf("failed to create LVM logical volume on node for LVMLogicalVolume %s, reason: LVMLogicalVolume is being deleted", lvmLogicalVolumeName)
 			}
 
 			if llv.Status.Phase == LLVStatusFailed {
-				return attemptCounter, fmt.Errorf("failed to create LVM logical volume on node for LVMLogicalVolume %s, reason: %s", lvmLogicalVolumeName, llv.Status.Reason)
+				return nil, attemptCounter, fmt.Errorf("failed to create LVM logical volume on node for LVMLogicalVolume %s, reason: %s", lvmLogicalVolumeName, llv.Status.Reason)
 			}
 
 			if llv.Status.Phase == LLVStatusCreated {
 				if llv.Status.ActualSize.Value() >= alignedSize.Value() {
-					return attemptCounter, nil
+					return llv, attemptCounter, nil
 				}
 				log.Trace(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume created but size does not match the requested size yet. Waiting...", traceID, lvmLogicalVolumeName, attemptCounter))
 			} else {

--- a/images/sds-local-volume-csi/pkg/utils/size_align_test.go
+++ b/images/sds-local-volume-csi/pkg/utils/size_align_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestAlignSizeToExtent(t *testing.T) {
+	extent := resource.MustParse("4Mi")
+
+	t.Run("rounds_up_unaligned_size_to_the_next_extent", func(t *testing.T) {
+		// 35Mi is a whole number of MiB but not a multiple of the 4Mi extent,
+		// so it must round up to 36Mi — this is exactly the drift the plain
+		// create path used to leave in Spec.Size and the reported capacity.
+		aligned, err := AlignSizeToExtent(resource.MustParse("35Mi"), extent)
+		assert.NoError(t, err)
+		expected := resource.MustParse("36Mi")
+		assert.Equal(t, expected.Value(), aligned.Value())
+	})
+
+	t.Run("leaves_already_aligned_size_unchanged", func(t *testing.T) {
+		aligned, err := AlignSizeToExtent(resource.MustParse("52Mi"), extent)
+		assert.NoError(t, err)
+		expected := resource.MustParse("52Mi")
+		assert.Equal(t, expected.Value(), aligned.Value())
+	})
+
+	t.Run("zero_size_stays_zero", func(t *testing.T) {
+		aligned, err := AlignSizeToExtent(resource.MustParse("0"), extent)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), aligned.Value())
+	})
+
+	t.Run("returns_error_for_non_positive_extent", func(t *testing.T) {
+		_, err := AlignSizeToExtent(resource.MustParse("35Mi"), resource.MustParse("0"))
+		assert.Error(t, err)
+	})
+}
+
+func TestSafeExtentSize(t *testing.T) {
+	t.Run("returns_extent_when_positive", func(t *testing.T) {
+		expected := resource.MustParse("8Mi")
+		actual := SafeExtentSize(resource.MustParse("8Mi"))
+		assert.Equal(t, expected.Value(), actual.Value())
+	})
+
+	t.Run("falls_back_to_4Mi_when_zero", func(t *testing.T) {
+		expected := resource.MustParse("4Mi")
+		actual := SafeExtentSize(resource.MustParse("0"))
+		assert.Equal(t, expected.Value(), actual.Value())
+	})
+}


### PR DESCRIPTION
## Problem

On `sds-local-volume`, a volume's reported capacity and a snapshot's `restoreSize` could be unaligned to the LVM extent — e.g. `35Mi`, a whole number of MiB but not a multiple of the 4Mi extent.

The non-content-source `CreateVolume` path stored the raw requested size in `LVMLogicalVolume.Spec.Size` and returned it verbatim as the PV capacity, while the node rounds the LV up to the extent boundary (36Mi). `CreateSnapshot` then copied `Spec.Size` into the snapshot `restoreSize`, propagating the drift. The snapshot/volume clone branches already aligned; only the plain path did not.

## Fix

- Align the requested size to the LVM extent in the plain-create path, via a single `alignToLVGExtentOrStatusErr` helper now shared by all three `CreateVolume` branches and by `ControllerExpandVolume`.
- Report the capacity from the created `LVMLogicalVolume`'s `Status.ActualSize` instead of the requested bytes — which is what `ControllerExpandVolume` already does. This reports what actually exists on the node in every case, including the clone branches where the size is derived from a source whose `Spec.Size` predates alignment, and removes a latent zero-capacity response when the requested size is `0`.
- Move the thick free-space check in the Immediate binding path after the alignment, so it is the aligned size that gets validated. A request fitting only before rounding used to pass the check and then fail on the node with a much less obvious `not enough space`, after `CreateVolume` had already blocked waiting for the LV.

### `CreateSnapshot` reports the actual size

`CreateSnapshot` now takes `SizeBytes` from `Status.ActualSize` rather than parsing `Spec.Size`. Volumes provisioned before this change keep an unaligned `Spec.Size`, so their snapshots used to advertise a `restoreSize` the source does not actually have; reading the status covers those too. The precondition at the top of the function already guarantees a non-zero `ActualSize`, and the thin-pool free-space check a few lines above is made against the same value.

### Reject a content source for a non-Thin storage class

The node clones and restores with `lvcreate -s`, which exists for thin volumes only. A `Thick` `LVMLogicalVolume` carrying a `Source` is created by the agent as an empty LV with the source dropped, so a snapshot restored into a thick storage class would produce a `Bound` PVC holding no data. `CreateVolume` now rejects the combination with `InvalidArgument`; the agent-side guard is in the paired PR.

### Error handling and duplication

- The `GetNodeWithMaxFreeSpace` error was logged and discarded. Its free-space value now feeds a check made further down the function, so it is propagated as `Internal` instead of letting a partially assigned result reach that decision unnoticed.
- `WaitForStatusUpdate` returns the `LVMLogicalVolume` it waited for. Both callers were issuing a second GET for the object the polling loop already held; that GET, and the window between the wait and the re-read, are gone.

## Related

This is the alignment half of the restore-from-snapshot investigation. The fatal "PVC stuck Pending on restore" bug is fixed on the node side (the cloned LV was never extended to the requested size): deckhouse/sds-node-configurator#318

## Testing

Unit tests for `AlignSizeToExtent` and `SafeExtentSize` (both pre-existing functions), which the alignment now relies on in every branch.

The new `CreateVolume` logic is covered through two extracted pure helpers in `driver/controller_test.go`:

- `fitsFreeSpace` — including the case the check was moved for (`aligned=36Mi` against `free=35Mi` must fail, where the raw `35Mi` request used to pass), plus the thin and WaitForFirstConsumer paths that are deliberately not checked;
- `resolveCapacityBytes` — status present, status missing, resource missing.

`CreateVolume` itself has no unit-test harness — `WaitForStatusUpdate` polls for a status only the node agent produces. There is no restore scenario in this module's e2e suite either; the end-to-end coverage for the restore path lives in deckhouse/sds-node-configurator#318.

- `go build -tags ee ./...` / `go build -tags ce ./...`
- `go test -tags ee ./...` / `go test -tags ce ./...`
- `go vet -tags ee ./...`
- `golangci-lint run --build-tags ee ./...` / `--build-tags ce ./...` — 0 issues