### PR TITLE
refactor(logger): move all components onto deckhouse/pkg/log

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,10 +10,36 @@ linters:
     - ineffassign
     - misspell
     - revive
+    - sloglint
     - staticcheck
     - unconvert
     - unparam
     - whitespace
+  settings:
+    sloglint:
+      # Scope: sloglint and govet's slog analyzer recognise log/slog and types
+      # embedding *slog.Logger, which covers deckhouse/pkg/log. They do NOT see
+      # calls made through the module's own logger.Logger wrapper, so these rules
+      # guard the logger package and any direct pkg/log use, not the ~360
+      # wrapper call sites.
+      #
+      # no-mixed-args is on by default and is the rule that matters most here: it
+      # allows a pure-attribute call such as log.Error(msg, log.Err(err)) and a
+      # pure key-value call such as log.Info(msg, "volumeID", id), but rejects
+      # mixing the two forms in one call. kv-only is deliberately NOT set,
+      # because it would outlaw log.Err(err), which is the intended way to log an
+      # error with this library.
+      #
+      # static-msg and no-raw-keys are left off: most messages are still built
+      # with fmt.Sprintf, and converting them is a separate change.
+      args-on-same-line: true
+      forbidden-keys:
+        # Reserved by the handler; shadowing them silently drops the real value.
+        - level
+        - msg
+        - source
+        - stacktrace
+        - time
   exclusions:
     generated: lax
     presets:

--- a/images/controller/cmd/main.go
+++ b/images/controller/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	goruntime "runtime"
 
@@ -64,28 +65,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info(fmt.Sprintf("[main] Go Version:%s ", goruntime.Version()))
-	log.Info(fmt.Sprintf("[main] OS/Arch:Go OS/Arch:%s/%s ", goruntime.GOOS, goruntime.GOARCH))
+	log.Info("starting the sds-local-volume controller", "goVersion", goruntime.Version(), "os", goruntime.GOOS, "arch", goruntime.GOARCH)
 
-	log.Info("[main] CfgParams has been successfully created")
-	log.Info(fmt.Sprintf("[main] %s = %s", config.LogLevel, cfgParams.Loglevel))
-	log.Info(fmt.Sprintf("[main] %s = %d", config.RequeueInterval, cfgParams.RequeueStorageClassInterval))
+	log.Info("configuration loaded", config.LogLevel, string(cfgParams.Loglevel), config.RequeueInterval, cfgParams.RequeueStorageClassInterval)
 
 	kConfig, err := kubutils.KubernetesDefaultConfigCreate()
 	if err != nil {
-		log.Error(err, "[main] unable to KubernetesDefaultConfigCreate")
+		log.Error("unable to create the kubernetes config", logger.Err(err))
 	}
-	log.Info("[main] kubernetes config has been successfully created.")
+	log.Info("kubernetes config created")
 
 	scheme := apiruntime.NewScheme()
 	for _, f := range resourcesSchemeFuncs {
 		err := f(scheme)
 		if err != nil {
-			log.Error(err, "[main] unable to add scheme to func")
+			log.Error("unable to add a resource to the scheme", logger.Err(err))
 			os.Exit(1)
 		}
 	}
-	log.Info("[main] successfully read scheme CR")
+	log.Info("scheme built")
 
 	// The storage keeps its own registry and is then plugged into the
 	// controller-runtime registry as a collector, so that a single metrics
@@ -93,15 +91,15 @@ func main() {
 	// (workqueue depth, reconcile totals, client-go latency).
 	metricStorage := metricsstorage.NewMetricStorage(metricsstorage.WithNewRegistry())
 	if err = monitoring.Register(metricStorage); err != nil {
-		log.Error(err, "[main] unable to register metrics")
+		log.Error("unable to register the metrics", logger.Err(err))
 		os.Exit(1)
 	}
 	if err = ctrlmetrics.Registry.Register(metricStorage.Collector()); err != nil {
-		log.Error(err, "[main] unable to add metrics to the controller-runtime registry")
+		log.Error("unable to add the metrics to the controller-runtime registry", logger.Err(err))
 		os.Exit(1)
 	}
 	metrics := monitoring.NewRecorder(metricStorage)
-	log.Info(fmt.Sprintf("[main] metrics are registered and served on %s/metrics", cfgParams.MetricsBindAddress))
+	log.Info("metrics registered", "address", cfgParams.MetricsBindAddress+"/metrics")
 
 	cacheOpt := cache.Options{
 		DefaultNamespaces: map[string]cache.Config{
@@ -124,36 +122,35 @@ func main() {
 
 	mgr, err := manager.New(kConfig, managerOpts)
 	if err != nil {
-		log.Error(err, "[main] unable to manager.New")
+		log.Error("unable to create the manager", logger.Err(err))
 		os.Exit(1)
 	}
-	log.Info("[main] successfully created kubernetes manager")
+	log.Info("manager created")
 
-	if _, err = controller.RunLocalStorageClassWatcherController(mgr, *cfgParams, *log, metrics); err != nil {
-		log.Error(err, fmt.Sprintf("[main] unable to run %s", controller.LocalStorageClassCtrlName))
+	if _, err = controller.RunLocalStorageClassWatcherController(mgr, *cfgParams, log, metrics); err != nil {
+		log.Error("unable to run the controller", logger.Err(err), slog.String("controller", controller.LocalStorageClassCtrlName))
 		os.Exit(1)
 	}
 
-	if _, err = controller.RunLocalCSINodeWatcherController(mgr, *cfgParams, *log, metrics); err != nil {
-		log.Error(err, fmt.Sprintf("[main] unable to run %s", controller.LocalCSINodeWatcherCtrl))
+	if _, err = controller.RunLocalCSINodeWatcherController(mgr, *cfgParams, log, metrics); err != nil {
+		log.Error("unable to run the controller", logger.Err(err), slog.String("controller", controller.LocalCSINodeWatcherCtrl))
 		os.Exit(1)
 	}
 
 	if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		log.Error(err, "[main] unable to mgr.AddHealthzCheck")
+		log.Error("unable to add the healthz check", logger.Err(err))
 		os.Exit(1)
 	}
-	log.Info("[main] successfully AddHealthzCheck")
 
 	if err = mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		log.Error(err, "[main] unable to mgr.AddReadyzCheck")
+		log.Error("unable to add the readyz check", logger.Err(err))
 		os.Exit(1)
 	}
-	log.Info("[main] successfully AddReadyzCheck")
+	log.Info("health probes registered")
 
 	err = mgr.Start(ctx)
 	if err != nil {
-		log.Error(err, "[main] unable to mgr.Start")
+		log.Error("the manager stopped with an error", logger.Err(err))
 		os.Exit(1)
 	}
 }

--- a/images/controller/go.mod
+++ b/images/controller/go.mod
@@ -1,7 +1,9 @@
 module github.com/deckhouse/sds-local-volume/images/controller
 
 go 1.26.5
+
 require (
+	github.com/deckhouse/deckhouse/pkg/log v0.2.1
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
 	github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787
 	github.com/deckhouse/sds-node-configurator/api v0.0.0-20260318114210-2fdda7b75905
@@ -13,7 +15,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
-	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/yaml v1.4.0
@@ -24,13 +25,11 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/deckhouse/deckhouse/pkg/log v0.1.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -57,8 +56,6 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
@@ -72,6 +69,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/images/controller/go.sum
+++ b/images/controller/go.sum
@@ -8,8 +8,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/deckhouse/pkg/log v0.1.0 h1:2aPfyiHHSIJlX4x7ysyPOaIb7CLmyY+hUf9uDb8TYd8=
-github.com/deckhouse/deckhouse/pkg/log v0.1.0/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
+github.com/deckhouse/deckhouse/pkg/log v0.2.1 h1:7SSD+QJPnziAO3l8ycgRwN5wlQeC312Tf7f2Wa/hWDg=
+github.com/deckhouse/deckhouse/pkg/log v0.2.1/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 h1:xZvbKuexrSQGEw6CB4n3UC7XbOb9QNLbm8UhcGZ2R1I=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0/go.mod h1:Rz++SzCLkFW03WGgftnn91TimGU2shiKb5S/YuxcBuE=
 github.com/deckhouse/sds-node-configurator/api v0.0.0-20260318114210-2fdda7b75905 h1:OKwOW3JFlbMxG8lLM9rfLxl+2M8lFpThQRFAJy4lBMQ=

--- a/images/controller/pkg/controller/controller_suite_test.go
+++ b/images/controller/pkg/controller/controller_suite_test.go
@@ -32,12 +32,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
+	"github.com/deckhouse/sds-local-volume/images/controller/pkg/logger"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite")
+}
+
+// NewTestLogger returns a logger writing into GinkgoWriter, so its output shows
+// up only for a failing spec.
+//
+// It panics rather than returning an error: the specs call it while Ginkgo is
+// still building the spec tree, before RegisterFailHandler has run, so Expect is
+// not usable here. TraceLevel is a constant, so the error is unreachable.
+func NewTestLogger() logger.Logger {
+	log, err := logger.NewLoggerToWriter(GinkgoWriter, logger.TraceLevel)
+	if err != nil {
+		panic(err)
+	}
+	return *log
 }
 
 func NewFakeClient() client.Client {

--- a/images/controller/pkg/controller/controller_suite_test.go
+++ b/images/controller/pkg/controller/controller_suite_test.go
@@ -52,7 +52,7 @@ func NewTestLogger() logger.Logger {
 	if err != nil {
 		panic(err)
 	}
-	return *log
+	return log
 }
 
 func NewFakeClient() client.Client {

--- a/images/controller/pkg/controller/local_csi_node_watcher.go
+++ b/images/controller/pkg/controller/local_csi_node_watcher.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -54,30 +55,31 @@ func RunLocalCSINodeWatcherController(
 	metrics monitoring.Recorder,
 ) (controller.Controller, error) {
 	cl := mgr.GetClient()
+	log = log.Named(LocalCSINodeWatcherCtrl)
 
 	c, err := controller.New(LocalCSINodeWatcherCtrl, mgr, controller.Options{
 		Reconciler: reconcile.Func(func(ctx context.Context, request reconcile.Request) (res reconcile.Result, err error) {
 			defer metrics.ObserveReconcile(LocalCSINodeWatcherCtrl, time.Now(), &res, &err)
 
-			log.Info(fmt.Sprintf("[RunLocalCSINodeWatcherController] Reconciler func starts a reconciliation for the request: %s", request.String()))
+			log.Info("start")
 			if request.Name == cfg.ConfigSecretName {
-				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] request name %s matches the target config secret name %s. Start to reconcile", request.Name, cfg.ConfigSecretName))
+				log.Debug("the request matches the config secret, reconciling", "configSecretName", cfg.ConfigSecretName)
 
-				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] tries to get a secret by the request %s", request.String()))
+				log.Debug("getting the secret")
 				secret, err := getSecret(ctx, cl, request.Namespace, request.Name)
 				if err != nil {
-					log.Error(err, fmt.Sprintf("[RunLocalCSINodeWatcherController] unable to get a secret by the request %s", request.String()))
+					log.Error("unable to get the secret", logger.Err(err))
 					return reconcile.Result{}, err
 				}
-				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] successfully got a secret by the request %s", request.String()))
+				log.Debug("got the secret")
 
-				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] tries to reconcile local CSI nodes for the secret %s/%s", secret.Namespace, secret.Name))
+				log.Debug("reconciling the local CSI nodes")
 				err = reconcileLocalCSINodes(ctx, cl, log, secret)
 				if err != nil {
-					log.Error(err, fmt.Sprintf("[RunLocalCSINodeWatcherController] unable to reconcile local CSI nodes for the secret %s/%s", secret.Namespace, secret.Name))
+					log.Error("unable to reconcile the local CSI nodes", logger.Err(err))
 					return reconcile.Result{}, err
 				}
-				log.Debug(fmt.Sprintf("[RunLocalCSINodeWatcherController] successfully reconciled local CSI nodes for the secret %s/%s", secret.Namespace, secret.Name))
+				log.Debug("reconciled the local CSI nodes")
 
 				return reconcile.Result{
 					RequeueAfter: cfg.RequeueSecretInterval * time.Second,
@@ -107,43 +109,40 @@ func getSecret(ctx context.Context, cl client.Client, namespace, name string) (*
 }
 
 func reconcileLocalCSINodes(ctx context.Context, cl client.Client, log logger.Logger, secret *v1.Secret) error {
-	log.Debug("[reconcileLocalCSINodes] tries to get a selector from the config")
+	log.Debug("reading the node selector from the config")
 	nodeSelector, err := getNodeSelectorFromConfig(secret)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLocalCSINodes] unable to get node selector from the secret %s/%s", secret.Namespace, secret.Name))
+		log.Error("unable to read the node selector from the secret", logger.Err(err), slog.String("secretNamespace", secret.Namespace), slog.String("secretName", secret.Name))
 		return err
 	}
-	log.Trace(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] node selector from the config: %v", nodeSelector))
-	log.Debug("[reconcileLocalCSINodes] successfully got a selector from the config")
+	log.Trace("read the node selector", "nodeSelector", nodeSelector)
 
-	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] tries to get kubernetes nodes by the selector %v", nodeSelector))
+	log.Debug("listing the nodes matching the selector", "nodeSelector", nodeSelector)
 	nodesWithSelector, err := getKubernetesNodesBySelector(ctx, cl, nodeSelector)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLocalCSINodes] unable to get nodes by selector %v", nodeSelector))
+		log.Error("unable to list the nodes matching the selector", logger.Err(err), slog.String("nodeSelector", fmt.Sprintf("%v", nodeSelector)))
 		return err
 	}
 	for _, n := range nodesWithSelector.Items {
-		log.Trace(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] node %s has been got by selector %v", n.Name, nodeSelector))
+		log.Trace("node matched the selector", "nodeName", n.Name)
 	}
-	log.Debug("[reconcileLocalCSINodes] successfully got kubernetes nodes by the selector")
 
 	labelNodesWithLocalCSIIfNeeded(ctx, cl, log, nodesWithSelector)
-	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] finished labeling the selected nodes with a label %s", localCsiNodeSelectorLabel))
+	log.Debug("labelled the selected nodes", "label", localCsiNodeSelectorLabel)
 
-	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] start to clear the nodes without the selector %v", nodeSelector))
-	log.Debug("[reconcileLocalCSINodes] tries to get all kubernetes nodes")
+	log.Debug("clearing the nodes that no longer match the selector")
+	log.Debug("listing all nodes")
 	nodes, err := getKubeNodes(ctx, cl)
 	if err != nil {
-		log.Error(err, "[reconcileLocalCSINodes] unable to get nodes")
+		log.Error("unable to list all nodes", logger.Err(err))
 		return err
 	}
 	for _, n := range nodes.Items {
-		log.Trace(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] node %s has been got", n.Name))
+		log.Trace("listed a node", "nodeName", n.Name)
 	}
-	log.Debug("[reconcileLocalCSINodes] successfully got all kubernetes nodes")
 
 	reconcileLocalCSILabels(ctx, cl, log, nodes, nodeSelector)
-	log.Debug(fmt.Sprintf("[reconcileLocalCSINodes] finished removing the label %s from the nodes without the selector %v", localCsiNodeSelectorLabel, nodeSelector))
+	log.Debug("removed the label from the nodes that no longer match the selector", "label", localCsiNodeSelectorLabel)
 
 	return nil
 }
@@ -151,42 +150,42 @@ func reconcileLocalCSINodes(ctx context.Context, cl client.Client, log logger.Lo
 func reconcileLocalCSILabels(ctx context.Context, cl client.Client, log logger.Logger, nodes *v1.NodeList, selector map[string]string) {
 	var err error
 	for _, node := range nodes.Items {
-		log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] starts the reconciliation for the node %s", node.Name))
+		log.Debug("reconciling a node", "nodeName", node.Name)
 		if labels.Set(selector).AsSelector().Matches(labels.Set(node.Labels)) {
-			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] no need to remove a label %s from the node %s as its labels match the selector", localCsiNodeSelectorLabel, node.Name))
+			log.Debug("the node still matches the selector, keeping the label", "label", localCsiNodeSelectorLabel, "nodeName", node.Name)
 
 			err = clearManualEvictionLabelsIfNeeded(ctx, cl, log, node)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to remove manual eviction labels %s, %s from the nodes, LVMVolumeGroup and LocalStorageClasses", nodeManualEvictionLabel, candidateManualEvictionLabel))
+				log.Error("unable to remove the manual eviction labels", logger.Err(err), slog.String("nodeLabel", nodeManualEvictionLabel), slog.String("candidateLabel", candidateManualEvictionLabel))
 			}
 			continue
 		}
 
 		if _, exist := node.Labels[localCsiNodeSelectorLabel]; !exist {
-			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] no need to remove a label %s from the node %s as it does not has the label", localCsiNodeSelectorLabel, node.Name))
+			log.Debug("the node does not carry the label, nothing to remove", "label", localCsiNodeSelectorLabel, "nodeName", node.Name)
 			continue
 		}
 
 		lvgsForManualEviction, lscsForManualEviction, err := getManuallyEvictedLVGsAndLSCs(ctx, cl, node)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to get LVMVolumeGroups for manual eviction for the node %s", node.Name))
+			log.Error("unable to get the LVMVolumeGroups for manual eviction", logger.Err(err), slog.String("nodeName", node.Name))
 			continue
 		}
 
 		if len(lvgsForManualEviction) == 0 &&
 			len(lscsForManualEviction) == 0 {
-			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] no dependent resources were found for the node %s. Label %s will be removed from the node", node.Name, localCsiNodeSelectorLabel))
+			log.Debug("no dependent resources, removing the label from the node", "nodeName", node.Name, "label", localCsiNodeSelectorLabel)
 
 			delete(node.Labels, localCsiNodeSelectorLabel)
 			delete(node.Labels, nodeManualEvictionLabel)
 
 			err = cl.Update(ctx, &node)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the node %s", node.Name))
+				log.Error("unable to update the node", logger.Err(err), slog.String("nodeName", node.Name))
 				continue
 			}
 
-			log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] the label %s has been successfully removed from the node %s", localCsiNodeSelectorLabel, node.Name))
+			log.Debug("removed the label from the node", "label", localCsiNodeSelectorLabel, "nodeName", node.Name)
 		} else {
 			lvgsNames := strings.Builder{}
 			for _, lvg := range lvgsForManualEviction {
@@ -196,46 +195,46 @@ func reconcileLocalCSILabels(ctx context.Context, cl client.Client, log logger.L
 			for _, lsc := range lscsForManualEviction {
 				lscNames.WriteString(fmt.Sprintf("%s ", lsc.Name))
 			}
-			log.Warning(fmt.Sprintf("[reconcileLocalCSILabels] unable to remove label %s from the node %s due to the node's LVMVolumeGroups %s are used in LocalStorageClasses %s", localCsiNodeSelectorLabel, node.Name, lvgsNames.String(), lscNames.String()))
+			log.Warn("cannot remove the label: the node LVMVolumeGroups are still used by LocalStorageClasses", "label", localCsiNodeSelectorLabel, "nodeName", node.Name, "lvmVolumeGroups", lvgsNames.String(), "localStorageClasses", lscNames.String())
 
 			added, err := addLabelOnTheNodeIfNotExist(ctx, cl, node, nodeManualEvictionLabel)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the node %s", node.Name))
+				log.Error("unable to update the node", logger.Err(err), slog.String("nodeName", node.Name))
 				continue
 			}
 			if !added {
-				log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] label %s has been already added to the node %s", nodeManualEvictionLabel, node.Name))
+				log.Debug("the node already carries the manual eviction label", "label", nodeManualEvictionLabel, "nodeName", node.Name)
 			} else {
-				log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] successfully added the label %s to the node %s", nodeManualEvictionLabel, node.Name))
+				log.Debug("added the manual eviction label to the node", "label", nodeManualEvictionLabel, "nodeName", node.Name)
 			}
 
 			for _, lvg := range lvgsForManualEviction {
 				added, err = addLabelOnTheLVGIfNotExist(ctx, cl, lvg, candidateManualEvictionLabel)
 				if err != nil {
-					log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the LVMVolumeGroup %s", lvg.Name))
+					log.Error("unable to update the LVMVolumeGroup", logger.Err(err), slog.String("lvgName", lvg.Name))
 					continue
 				}
 				if !added {
-					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] label %s has been already added to the LVMVolumeGroup %s", candidateManualEvictionLabel, lvg.Name))
+					log.Debug("the LVMVolumeGroup already carries the candidate label", "label", candidateManualEvictionLabel, "lvgName", lvg.Name)
 				} else {
-					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] successfully added the label %s to the LVMVolumeGroup %s", candidateManualEvictionLabel, lvg.Name))
+					log.Debug("added the candidate label to the LVMVolumeGroup", "label", candidateManualEvictionLabel, "lvgName", lvg.Name)
 				}
 			}
 
 			for _, lsc := range lscsForManualEviction {
 				added, err = addLabelOnTheLSCIfNotExist(ctx, cl, lsc, candidateManualEvictionLabel)
 				if err != nil {
-					log.Error(err, fmt.Sprintf("[reconcileLocalCSILabels] unable to update the LocalStorageClass %s", lsc.Name))
+					log.Error("unable to update the LocalStorageClass", logger.Err(err), slog.String("localStorageClass", lsc.Name))
 					continue
 				}
 				if !added {
-					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] label %s has been already added to the LocalStorageClass %s", candidateManualEvictionLabel, lsc.Name))
+					log.Debug("the LocalStorageClass already carries the candidate label", "label", candidateManualEvictionLabel, "localStorageClass", lsc.Name)
 				} else {
-					log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] successfully added the label %s to the LocalStorageClass %s", candidateManualEvictionLabel, lsc.Name))
+					log.Debug("added the candidate label to the LocalStorageClass", "label", candidateManualEvictionLabel, "localStorageClass", lsc.Name)
 				}
 			}
 		}
-		log.Debug(fmt.Sprintf("[reconcileLocalCSILabels] ends the reconciliation for the node %s", node.Name))
+		log.Debug("reconciled a node", "nodeName", node.Name)
 	}
 }
 
@@ -290,20 +289,20 @@ func addLabelOnTheNodeIfNotExist(ctx context.Context, cl client.Client, node v1.
 
 func clearManualEvictionLabelsIfNeeded(ctx context.Context, cl client.Client, log logger.Logger, node v1.Node) error {
 	if _, exist := node.Labels[nodeManualEvictionLabel]; !exist {
-		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the node %s does not have the label %s", node.Name, nodeManualEvictionLabel))
+		log.Debug("the node does not carry the label", "nodeName", node.Name, "label", nodeManualEvictionLabel)
 	} else {
-		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the node %s has the label %s. It will be removed", node.Name, nodeManualEvictionLabel))
+		log.Debug("removing the label from the node", "nodeName", node.Name, "label", nodeManualEvictionLabel)
 		delete(node.Labels, nodeManualEvictionLabel)
 		err := cl.Update(ctx, &node)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] unable to update the node %s", node.Name))
+			log.Error("unable to update the node", logger.Err(err), slog.String("nodeName", node.Name))
 			return err
 		}
 	}
 
 	lvgList, err := getLVMVolumeGroups(ctx, cl)
 	if err != nil {
-		log.Error(err, "[clearManualEvictionLabelsIfNeeded] unable to get LVMVolumeGroups")
+		log.Error("unable to list the LVMVolumeGroups", logger.Err(err))
 		return err
 	}
 
@@ -321,23 +320,23 @@ func clearManualEvictionLabelsIfNeeded(ctx context.Context, cl client.Client, lo
 		}
 	}
 
-	log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] starts the removing label %s from the LVMVolumeGroups for the node %s", candidateManualEvictionLabel, node.Name))
+	log.Debug("removing the candidate label from the node LVMVolumeGroups", "label", candidateManualEvictionLabel, "nodeName", node.Name)
 	for _, lvg := range usedLvgs {
 		if _, exist := lvg.Labels[candidateManualEvictionLabel]; !exist {
-			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LVMVolumeGroup %s does not has the label %s", lvg.Name, candidateManualEvictionLabel))
+			log.Debug("the LVMVolumeGroup does not carry the label", "lvgName", lvg.Name, "label", candidateManualEvictionLabel)
 			continue
 		}
 
-		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LVMVolumeGroup %s has a label %s. It will be removed", lvg.Name, candidateManualEvictionLabel))
+		log.Debug("removing the label from the LVMVolumeGroup", "lvgName", lvg.Name, "label", candidateManualEvictionLabel)
 		delete(lvg.Labels, candidateManualEvictionLabel)
 		err = cl.Update(ctx, &lvg)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] unable to update the LVMVolumeGroup %s", lvg.Name))
+			log.Error("unable to update the LVMVolumeGroup", logger.Err(err), slog.String("lvgName", lvg.Name))
 			continue
 		}
-		log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LVMVolumeGroup %s label %s has been successfully removed", lvg.Name, candidateManualEvictionLabel))
+		log.Debug("removed the label from the LVMVolumeGroup", "lvgName", lvg.Name, "label", candidateManualEvictionLabel)
 	}
-	log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] finished the removing label %s from the LVMVolumeGroups for the node %s", candidateManualEvictionLabel, node.Name))
+	log.Debug("removed the candidate label from the node LVMVolumeGroups", "label", candidateManualEvictionLabel, "nodeName", node.Name)
 
 	lscList, err := getLocalStorageClasses(ctx, cl)
 	if err != nil {
@@ -346,7 +345,7 @@ func clearManualEvictionLabelsIfNeeded(ctx context.Context, cl client.Client, lo
 
 	for _, lsc := range lscList.Items {
 		if _, exist := lsc.Labels[candidateManualEvictionLabel]; !exist {
-			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LocalStorageClass %s does not have the label %s", lsc.Name, candidateManualEvictionLabel))
+			log.Debug("the LocalStorageClass does not carry the label", "localStorageClass", lsc.Name, "label", candidateManualEvictionLabel)
 			continue
 		}
 
@@ -362,17 +361,17 @@ func clearManualEvictionLabelsIfNeeded(ctx context.Context, cl client.Client, lo
 		}
 
 		if !healthy {
-			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LocalStorageClass has manually evicted LVMVolumeGroups %s. The label %s will not be removed", badLVGs.String(), candidateManualEvictionLabel))
+			log.Debug("the LocalStorageClass still has manually evicted LVMVolumeGroups, keeping the label", "lvmVolumeGroups", badLVGs.String(), "label", candidateManualEvictionLabel)
 		} else {
-			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] the LocalStorageClass does not have any manually evicted LVMVolumeGroup. The label %s will be removed", candidateManualEvictionLabel))
+			log.Debug("the LocalStorageClass has no manually evicted LVMVolumeGroup, removing the label", "label", candidateManualEvictionLabel)
 
 			delete(lsc.Labels, candidateManualEvictionLabel)
 			err = cl.Update(ctx, &lsc)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] unable to update the LocalStorageClass %s", lsc.Name))
+				log.Error("unable to update the LocalStorageClass", logger.Err(err), slog.String("localStorageClass", lsc.Name))
 				continue
 			}
-			log.Debug(fmt.Sprintf("[clearManualEvictionLabelsIfNeeded] successfully removed the label %s from the LocalStorageClass %s", candidateManualEvictionLabel, lsc.Name))
+			log.Debug("removed the label from the LocalStorageClass", "label", candidateManualEvictionLabel, "localStorageClass", lsc.Name)
 		}
 	}
 
@@ -461,7 +460,7 @@ func labelNodesWithLocalCSIIfNeeded(ctx context.Context, cl client.Client, log l
 	var err error
 	for _, node := range nodes.Items {
 		if _, exist := node.Labels[localCsiNodeSelectorLabel]; exist {
-			log.Debug(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] a node %s has already been labeled with label %s", node.Name, localCsiNodeSelectorLabel))
+			log.Debug("the node is already labelled", "nodeName", node.Name, "label", localCsiNodeSelectorLabel)
 			continue
 		}
 
@@ -469,10 +468,10 @@ func labelNodesWithLocalCSIIfNeeded(ctx context.Context, cl client.Client, log l
 
 		err = cl.Update(ctx, &node)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] unable to update a node %s", node.Name))
+			log.Error("unable to update the node", logger.Err(err), slog.String("nodeName", node.Name))
 			continue
 		}
 
-		log.Debug(fmt.Sprintf("[labelNodesWithLocalCSIIfNeeded] successufully added label %s to the node %s", localCsiNodeSelectorLabel, node.Name))
+		log.Debug("added the label to the node", "label", localCsiNodeSelectorLabel, "nodeName", node.Name)
 	}
 }

--- a/images/controller/pkg/controller/local_csi_node_watcher_test.go
+++ b/images/controller/pkg/controller/local_csi_node_watcher_test.go
@@ -35,7 +35,7 @@ import (
 func TestRunLocalCSINodeWatcherController(t *testing.T) {
 	cl := NewFakeClient()
 	ctx := context.Background()
-	log := logger.Logger{}
+	log := logger.NewNop()
 
 	t.Run("getSecret_returns_secret", func(t *testing.T) {
 		secretName := "test-name"

--- a/images/controller/pkg/controller/local_storage_class_watcher.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher.go
@@ -99,7 +99,7 @@ func RunLocalStorageClassWatcherController(
 		Reconciler: reconcile.Func(func(ctx context.Context, request reconcile.Request) (res reconcile.Result, err error) {
 			defer metrics.ObserveReconcile(LocalStorageClassCtrlName, time.Now(), &res, &err)
 
-			log.Info("[LocalStorageClassReconciler] starts Reconcile for the LocalStorageClass %s", request.Name)
+			log.Info(fmt.Sprintf("[LocalStorageClassReconciler] starts Reconcile for the LocalStorageClass %s", request.Name))
 			lsc := &slv.LocalStorageClass{}
 			err = cl.Get(ctx, request.NamespacedName, lsc)
 			if err != nil && !errors2.IsNotFound(err) {
@@ -152,7 +152,7 @@ func RunLocalStorageClassWatcherController(
 				}, nil
 			}
 
-			log.Info("[LocalStorageClassReconciler] ends Reconcile for the LocalStorageClass %q", request.Name)
+			log.Info(fmt.Sprintf("[LocalStorageClassReconciler] ends Reconcile for the LocalStorageClass %q", request.Name))
 			return reconcile.Result{}, nil
 		}),
 	})

--- a/images/controller/pkg/controller/local_storage_class_watcher.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"time"
 
@@ -94,21 +95,24 @@ func RunLocalStorageClassWatcherController(
 	metrics monitoring.Recorder,
 ) (controller.Controller, error) {
 	cl := mgr.GetClient()
+	log = log.Named(LocalStorageClassCtrlName)
 
 	c, err := controller.New(LocalStorageClassCtrlName, mgr, controller.Options{
 		Reconciler: reconcile.Func(func(ctx context.Context, request reconcile.Request) (res reconcile.Result, err error) {
 			defer metrics.ObserveReconcile(LocalStorageClassCtrlName, time.Now(), &res, &err)
 
-			log.Info(fmt.Sprintf("[LocalStorageClassReconciler] starts Reconcile for the LocalStorageClass %s", request.Name))
+			log := log.Named("reconcile").With("localStorageClass", request.Name)
+
+			log.Info("start")
 			lsc := &slv.LocalStorageClass{}
 			err = cl.Get(ctx, request.NamespacedName, lsc)
 			if err != nil && !errors2.IsNotFound(err) {
-				log.Error(err, fmt.Sprintf("[LocalStorageClassReconciler] unable to get LocalStorageClass, name: %s", request.Name))
+				log.Error("unable to get the LocalStorageClass", logger.Err(err))
 				return reconcile.Result{}, err
 			}
 
 			if lsc.Name == "" {
-				log.Info(fmt.Sprintf("[LocalStorageClassReconciler] seems like the LocalStorageClass for the request %s was deleted. Reconcile retrying will stop.", request.Name))
+				log.Info("the LocalStorageClass was deleted, stopping the reconcile")
 				// The resource is gone, so stop exporting its phase gauge.
 				metrics.ForgetLocalStorageClass(request.Name)
 				return reconcile.Result{}, nil
@@ -117,7 +121,7 @@ func RunLocalStorageClassWatcherController(
 			scList := &v1.StorageClassList{}
 			err = cl.List(ctx, scList)
 			if err != nil {
-				log.Error(err, "[LocalStorageClassReconciler] unable to list Storage Classes")
+				log.Error("unable to list the StorageClasses", logger.Err(err))
 				return reconcile.Result{}, err
 			}
 
@@ -127,7 +131,7 @@ func RunLocalStorageClassWatcherController(
 			// which is exactly the bug this controller is meant to prevent.
 			ignoredLabelPrefixes, err := getStorageClassLabelIgnoredPrefixes(ctx, cl, cfg.ControllerNamespace, cfg.ConfigSecretName)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[LocalStorageClassReconciler] unable to load storage class label ignored prefixes from secret %s/%s; requeueing without applying reconcile", cfg.ControllerNamespace, cfg.ConfigSecretName))
+				log.Error("unable to load the ignored storage class label prefixes, requeueing without reconciling", logger.Err(err), slog.String("secretNamespace", cfg.ControllerNamespace), slog.String("secretName", cfg.ConfigSecretName))
 				return reconcile.Result{
 					RequeueAfter: cfg.RequeueStorageClassInterval * time.Second,
 				}, nil
@@ -135,7 +139,7 @@ func RunLocalStorageClassWatcherController(
 
 			shouldRequeue, err := RunEventReconcile(ctx, cl, log, scList, lsc, ignoredLabelPrefixes)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[LocalStorageClassReconciler] an error occurred while reconciles the LocalStorageClass, name: %s", lsc.Name))
+				log.Error("unable to reconcile the LocalStorageClass", logger.Err(err))
 			}
 
 			// RunEventReconcile updates lsc.Status.Phase in place, so this reads
@@ -146,29 +150,29 @@ func RunLocalStorageClassWatcherController(
 			}
 
 			if shouldRequeue {
-				log.Warning(fmt.Sprintf("[LocalStorageClassReconciler] Reconciler will requeue the request, name: %s", request.Name))
+				log.Warn("requeueing the request")
 				return reconcile.Result{
 					RequeueAfter: cfg.RequeueStorageClassInterval * time.Second,
 				}, nil
 			}
 
-			log.Info(fmt.Sprintf("[LocalStorageClassReconciler] ends Reconcile for the LocalStorageClass %q", request.Name))
+			log.Info("done")
 			return reconcile.Result{}, nil
 		}),
 	})
 	if err != nil {
-		log.Error(err, "[RunLocalStorageClassWatcherController] unable to create controller")
+		log.Error("unable to create the controller", logger.Err(err))
 		return nil, err
 	}
 
 	err = c.Watch(source.Kind(mgr.GetCache(), &slv.LocalStorageClass{}, handler.TypedFuncs[*slv.LocalStorageClass, reconcile.Request]{
 		CreateFunc: func(_ context.Context, e event.TypedCreateEvent[*slv.LocalStorageClass], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			log.Info(fmt.Sprintf("[CreateFunc] get event for LocalStorageClass %q. Add to the queue", e.Object.GetName()))
+			log.Named("create-event").Info("enqueueing the LocalStorageClass", "localStorageClass", e.Object.GetName())
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: e.Object.GetNamespace(), Name: e.Object.GetName()}}
 			q.Add(request)
 		},
 		UpdateFunc: func(_ context.Context, e event.TypedUpdateEvent[*slv.LocalStorageClass], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			log.Info(fmt.Sprintf("[UpdateFunc] get event for LocalStorageClass %q. Check if it should be reconciled", e.ObjectNew.GetName()))
+			log.Named("update-event").Info("checking whether the LocalStorageClass should be reconciled", "localStorageClass", e.ObjectNew.GetName())
 
 			oldLsc := e.ObjectOld
 			newLsc := e.ObjectNew
@@ -176,11 +180,11 @@ func RunLocalStorageClassWatcherController(
 			if reflect.DeepEqual(oldLsc.Spec, newLsc.Spec) &&
 				reflect.DeepEqual(oldLsc.Labels, newLsc.Labels) &&
 				newLsc.DeletionTimestamp == nil {
-				log.Info(fmt.Sprintf("[UpdateFunc] an update event for the LocalStorageClass %s has no Spec or Labels updates. It will not be reconciled", newLsc.Name))
+				log.Named("update-event").Info("the update touched neither spec nor labels, not reconciling", "localStorageClass", newLsc.Name)
 				return
 			}
 
-			log.Info(fmt.Sprintf("[UpdateFunc] the LocalStorageClass %q will be reconciled. Add to the queue", newLsc.Name))
+			log.Named("update-event").Info("enqueueing the LocalStorageClass", "localStorageClass", newLsc.Name)
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: newLsc.Namespace, Name: newLsc.Name}}
 			q.Add(request)
 		},
@@ -188,7 +192,7 @@ func RunLocalStorageClassWatcherController(
 	),
 	)
 	if err != nil {
-		log.Error(err, "[RunLocalStorageClassWatcherController] unable to watch the events")
+		log.Error("unable to watch LocalStorageClass events", logger.Err(err))
 		return nil, err
 	}
 
@@ -204,10 +208,10 @@ func RunLocalStorageClassWatcherController(
 				if s == nil || s.Namespace != cfg.ControllerNamespace || s.Name != cfg.ConfigSecretName {
 					return nil
 				}
-				log.Info(fmt.Sprintf("[SecretWatcher] controller-config Secret %s/%s changed; enqueueing all LocalStorageClasses", s.Namespace, s.Name))
+				log.Named("secret-watcher").Info("the controller-config Secret changed, enqueueing all LocalStorageClasses", "secretNamespace", s.Namespace, "secretName", s.Name)
 				lscList := &slv.LocalStorageClassList{}
 				if err := cl.List(ctx, lscList); err != nil {
-					log.Error(err, "[SecretWatcher] unable to list LocalStorageClasses for re-reconcile after config Secret change")
+					log.Named("secret-watcher").Error("unable to list the LocalStorageClasses after a config Secret change", logger.Err(err))
 					return nil
 				}
 				reqs := make([]reconcile.Request, 0, len(lscList.Items))
@@ -221,7 +225,7 @@ func RunLocalStorageClassWatcherController(
 		),
 	))
 	if err != nil {
-		log.Error(err, "[RunLocalStorageClassWatcherController] unable to watch the controller-config Secret")
+		log.Error("unable to watch the controller-config Secret", logger.Err(err))
 		return nil, err
 	}
 
@@ -237,7 +241,7 @@ func RunLocalStorageClassWatcherController(
 			func(ctx context.Context, _ *snc.LVMVolumeGroup) []reconcile.Request {
 				lscList := &slv.LocalStorageClassList{}
 				if err := cl.List(ctx, lscList); err != nil {
-					log.Error(err, "[LVGWatcher] unable to list LocalStorageClasses for re-reconcile after LVMVolumeGroup change")
+					log.Named("lvg-watcher").Error("unable to list the LocalStorageClasses after an LVMVolumeGroup change", logger.Err(err))
 					return nil
 				}
 				reqs := make([]reconcile.Request, 0, len(lscList.Items))
@@ -267,7 +271,7 @@ func RunLocalStorageClassWatcherController(
 		},
 	))
 	if err != nil {
-		log.Error(err, "[RunLocalStorageClassWatcherController] unable to watch LVMVolumeGroups")
+		log.Error("unable to watch the LVMVolumeGroups", logger.Err(err))
 		return nil, err
 	}
 
@@ -282,7 +286,7 @@ func RunEventReconcile(ctx context.Context, cl client.Client, log logger.Logger,
 	lvgList := &snc.LVMVolumeGroupList{}
 	if lsc.DeletionTimestamp == nil {
 		if err := cl.List(ctx, lvgList); err != nil {
-			log.Error(err, fmt.Sprintf("[runEventReconcile] unable to list LVMVolumeGroups for the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to list the LVMVolumeGroups for the LocalStorageClass", logger.Err(err), slog.String("localStorageClass", lsc.Name))
 			upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 			if upError != nil {
 				err = errors.Join(err, fmt.Errorf("[runEventReconcile] unable to update the LocalStorageClass %s status: %w", lsc.Name, upError))
@@ -293,7 +297,7 @@ func RunEventReconcile(ctx context.Context, cl client.Client, log logger.Logger,
 
 	effectiveLVGs, err := resolveEffectiveLVGs(lsc, lvgList)
 	if err != nil && lsc.DeletionTimestamp == nil {
-		log.Error(err, fmt.Sprintf("[runEventReconcile] unable to resolve LVMVolumeGroups for the LocalStorageClass %s", lsc.Name))
+		log.Error("unable to resolve the LVMVolumeGroups for the LocalStorageClass", logger.Err(err), slog.String("localStorageClass", lsc.Name))
 		upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 		if upError != nil {
 			err = errors.Join(err, fmt.Errorf("[runEventReconcile] unable to update the LocalStorageClass %s status: %w", lsc.Name, upError))
@@ -311,19 +315,19 @@ func RunEventReconcile(ctx context.Context, cl client.Client, log logger.Logger,
 		return true, err
 	}
 
-	log.Debug(fmt.Sprintf("[runEventReconcile] reconcile operation: %s", recType))
+	log.Debug("resolved the reconcile type", "reconcileType", recType)
 	switch recType {
 	case CreateReconcile:
-		log.Debug(fmt.Sprintf("[runEventReconcile] CreateReconcile starts reconciliataion for the LocalStorageClass, name: %s", lsc.Name))
+		log.Debug("running the create reconcile", "localStorageClass", lsc.Name)
 		return reconcileLSCCreateFunc(ctx, cl, log, scList, lsc, lvgList, effectiveLVGs, ignoredLabelPrefixes)
 	case UpdateReconcile:
-		log.Debug(fmt.Sprintf("[runEventReconcile] UpdateReconcile starts reconciliataion for the LocalStorageClass, name: %s", lsc.Name))
+		log.Debug("running the update reconcile", "localStorageClass", lsc.Name)
 		return reconcileLSCUpdateFunc(ctx, cl, log, scList, lsc, lvgList, effectiveLVGs, ignoredLabelPrefixes)
 	case DeleteReconcile:
-		log.Debug(fmt.Sprintf("[runEventReconcile] DeleteReconcile starts reconciliataion for the LocalStorageClass, name: %s", lsc.Name))
+		log.Debug("running the delete reconcile", "localStorageClass", lsc.Name)
 		return reconcileLSCDeleteFunc(ctx, cl, log, scList, lsc)
 	default:
-		log.Debug(fmt.Sprintf("[runEventReconcile] the LocalStorageClass %s should not be reconciled", lsc.Name))
+		log.Debug("the LocalStorageClass should not be reconciled", "localStorageClass", lsc.Name)
 	}
 
 	return false, nil

--- a/images/controller/pkg/controller/local_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher_func.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"sort"
 	"strings"
@@ -142,7 +143,9 @@ func reconcileLSCDeleteFunc(
 	scList *v1.StorageClassList,
 	lsc *slv.LocalStorageClass,
 ) (bool, error) {
-	log.Debug(fmt.Sprintf("[reconcileLSCDeleteFunc] tries to find a storage class for the LocalStorageClass %s", lsc.Name))
+	log = log.Named("delete").With("localStorageClass", lsc.Name)
+
+	log.Debug("looking for the managed StorageClass")
 	var sc *v1.StorageClass
 	for _, s := range scList.Items {
 		if s.Name == lsc.Name {
@@ -151,44 +154,44 @@ func reconcileLSCDeleteFunc(
 		}
 	}
 	if sc == nil {
-		log.Info(fmt.Sprintf("[reconcileLSCDeleteFunc] no storage class found for the LocalStorageClass, name: %s", lsc.Name))
+		log.Info("no managed StorageClass found")
 	}
 
 	if sc != nil {
-		log.Info(fmt.Sprintf("[reconcileLSCDeleteFunc] successfully found a storage class for the LocalStorageClass %s", lsc.Name))
-		log.Debug(fmt.Sprintf("[reconcileLSCDeleteFunc] starts identifing a provisioner for the storage class %s", sc.Name))
+		log.Info("found the managed StorageClass")
+		log.Debug("identifying the StorageClass provisioner", "storageClass", sc.Name)
 
 		if sc.Provisioner != LocalStorageClassProvisioner {
-			log.Info(fmt.Sprintf("[reconcileLSCDeleteFunc] the storage class %s does not belongs to %s provisioner. It will not be deleted", sc.Name, LocalStorageClassProvisioner))
+			log.Info("the StorageClass belongs to another provisioner, not deleting it", "storageClass", sc.Name, "provisioner", LocalStorageClassProvisioner)
 		} else {
-			log.Info(fmt.Sprintf("[reconcileLSCDeleteFunc] the storage class %s belongs to %s provisioner. It will be deleted", sc.Name, LocalStorageClassProvisioner))
+			log.Info("deleting the StorageClass", "storageClass", sc.Name, "provisioner", LocalStorageClassProvisioner)
 
 			err := deleteStorageClass(ctx, cl, sc)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[reconcileLSCDeleteFunc] unable to delete a storage class, name: %s", sc.Name))
+				log.Error("unable to delete the StorageClass", logger.Err(err), slog.String("storageClass", sc.Name))
 				upErr := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, fmt.Sprintf("Unable to delete a storage class, err: %s", err.Error()))
 				if upErr != nil {
-					log.Error(upErr, fmt.Sprintf("[reconcileLSCDeleteFunc] unable to update the LocalStorageClass, name: %s", lsc.Name))
+					log.Error("unable to update the LocalStorageClass status", logger.Err(upErr))
 				}
 				return true, err
 			}
-			log.Info(fmt.Sprintf("[reconcileLSCDeleteFunc] successfully deleted a storage class, name: %s", sc.Name))
+			log.Info("deleted the StorageClass", "storageClass", sc.Name)
 		}
 	}
 
-	log.Debug(fmt.Sprintf("[reconcileLSCDeleteFunc] starts removing a finalizer %s from the LocalStorageClass, name: %s", LocalStorageClassFinalizerName, lsc.Name))
+	log.Debug("removing the finalizer", "finalizer", LocalStorageClassFinalizerName)
 	removed, err := removeFinalizerIfExists(ctx, cl, lsc, LocalStorageClassFinalizerName)
 	if err != nil {
-		log.Error(err, "[reconcileLSCDeleteFunc] unable to remove a finalizer %s from the LocalStorageClass, name: %s", LocalStorageClassFinalizerName, lsc.Name)
+		log.Error("unable to remove the finalizer", logger.Err(err), slog.String("finalizer", LocalStorageClassFinalizerName))
 		upErr := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, fmt.Sprintf("Unable to remove a finalizer, err: %s", err.Error()))
 		if upErr != nil {
-			log.Error(upErr, fmt.Sprintf("[reconcileLSCDeleteFunc] unable to update the LocalStorageClass, name: %s", lsc.Name))
+			log.Error("unable to update the LocalStorageClass status", logger.Err(upErr))
 		}
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCDeleteFunc] the LocalStorageClass %s finalizer %s was removed: %t", lsc.Name, LocalStorageClassFinalizerName, removed))
+	log.Debug("finalizer removal result", "finalizer", LocalStorageClassFinalizerName, "removed", removed)
 
-	log.Debug("[reconcileLSCDeleteFunc] ends the reconciliation")
+	log.Debug("done")
 	return false, nil
 }
 
@@ -202,19 +205,21 @@ func reconcileLSCUpdateFunc(
 	effectiveLVGs []slv.LocalStorageClassLVG,
 	ignoredLabelPrefixes []string,
 ) (bool, error) {
-	log.Debug(fmt.Sprintf("[reconcileLSCUpdateFunc] starts the LocalStorageClass %s validation", lsc.Name))
+	log = log.Named("update").With("localStorageClass", lsc.Name)
+
+	log.Debug("validating the LocalStorageClass")
 	valid, msg := validateLocalStorageClass(scList, lsc, lvgList, effectiveLVGs)
 	if !valid {
 		err := fmt.Errorf("validation failed: %s", msg)
-		log.Error(err, fmt.Sprintf("[reconcileLSCUpdateFunc] Unable to reconcile the LocalStorageClass, name: %s", lsc.Name))
+		log.Error("the LocalStorageClass is invalid", logger.Err(err))
 		upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, msg)
 		if upError != nil {
-			log.Error(upError, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 		}
 
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCUpdateFunc] successfully validated the LocalStorageClass, name: %s", lsc.Name))
+	log.Debug("the LocalStorageClass is valid")
 
 	var oldSC *v1.StorageClass
 	for _, s := range scList.Items {
@@ -225,36 +230,36 @@ func reconcileLSCUpdateFunc(
 	}
 	if oldSC == nil {
 		err := fmt.Errorf("a storage class %s does not exist", lsc.Name)
-		log.Error(err, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to find a storage class for the LocalStorageClass, name: %s", lsc.Name))
+		log.Error("unable to find the managed StorageClass", logger.Err(err))
 		upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 		if upError != nil {
-			log.Error(upError, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 		}
 		return true, err
 	}
 
-	log.Debug(fmt.Sprintf("[reconcileLSCUpdateFunc] successfully found a storage class for the LocalStorageClass, name: %s", lsc.Name))
+	log.Debug("found the managed StorageClass")
 
-	log.Trace(fmt.Sprintf("[reconcileLSCUpdateFunc] storage class %s params: %+v", oldSC.Name, oldSC.Parameters))
-	log.Trace(fmt.Sprintf("[reconcileLSCUpdateFunc] LocalStorageClass %s Spec.LVM: %+v", lsc.Name, lsc.Spec.LVM))
+	log.Trace("current StorageClass parameters", "storageClass", oldSC.Name, "parameters", fmt.Sprintf("%+v", oldSC.Parameters))
+	log.Trace("LocalStorageClass LVM spec", "lvm", fmt.Sprintf("%+v", lsc.Spec.LVM))
 	hasDiff, err := hasSCDiff(oldSC, lsc, effectiveLVGs, ignoredLabelPrefixes)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to identify the LVMVolumeGroup difference for the LocalStorageClass %s", lsc.Name))
+		log.Error("unable to determine the LVMVolumeGroup difference", logger.Err(err))
 		upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 		if upError != nil {
-			log.Error(upError, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 		}
 		return true, err
 	}
 
 	if hasDiff {
-		log.Info(fmt.Sprintf("[reconcileLSCUpdateFunc] current Storage Class LVMVolumeGroups do not match LocalStorageClass ones. The Storage Class %s will be recreated with new ones", lsc.Name))
+		log.Info("the StorageClass LVMVolumeGroups no longer match, recreating the StorageClass")
 		newSC, err := updateStorageClass(lsc, oldSC, effectiveLVGs, ignoredLabelPrefixes)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to configure a Storage Class for the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to build the StorageClass", logger.Err(err))
 			upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 			if upError != nil {
-				log.Error(upError, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+				log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 				return true, upError
 			}
 			return false, err
@@ -262,23 +267,23 @@ func reconcileLSCUpdateFunc(
 
 		err = recreateStorageClass(ctx, cl, oldSC, newSC)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to recreate a Storage Class %s", newSC.Name))
+			log.Error("unable to recreate the StorageClass", logger.Err(err), slog.String("storageClass", newSC.Name))
 			upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 			if upError != nil {
-				log.Error(upError, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+				log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 			}
 			return true, err
 		}
 
-		log.Info(fmt.Sprintf("[reconcileLSCUpdateFunc] a Storage Class %s was successfully recreated", newSC.Name))
+		log.Info("recreated the StorageClass", "storageClass", newSC.Name)
 	}
 
 	err = updateLocalStorageClassPhase(ctx, cl, lsc, CreatedStatusPhase, "")
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLSCUpdateFunc] unable to update the LocalStorageClass, name: %s", lsc.Name))
+		log.Error("unable to update the LocalStorageClass status", logger.Err(err))
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCUpdateFunc] successfully updated the LocalStorageClass %s status", lsc.Name))
+	log.Debug("updated the LocalStorageClass status")
 
 	return false, nil
 }
@@ -468,71 +473,73 @@ func reconcileLSCCreateFunc(
 	effectiveLVGs []slv.LocalStorageClassLVG,
 	ignoredLabelPrefixes []string,
 ) (bool, error) {
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] starts the LocalStorageClass %s validation", lsc.Name))
+	log = log.Named("create").With("localStorageClass", lsc.Name)
+
+	log.Debug("validating the LocalStorageClass")
 	added, err := addFinalizerIfNotExistsForLSC(ctx, cl, lsc)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLSCCreateFunc] unable to add a finalizer %s to the LocalStorageClass %s", LocalStorageClassFinalizerName, lsc.Name))
+		log.Error("unable to add the finalizer to the LocalStorageClass", logger.Err(err), slog.String("finalizer", LocalStorageClassFinalizerName))
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] finalizer %s was added to the LocalStorageClass %s: %t", LocalStorageClassFinalizerName, lsc.Name, added))
+	log.Debug("finalizer addition result", "finalizer", LocalStorageClassFinalizerName, "added", added)
 
 	valid, msg := validateLocalStorageClass(scList, lsc, lvgList, effectiveLVGs)
 	if !valid {
 		err := fmt.Errorf("validation failed: %s", msg)
-		log.Error(err, fmt.Sprintf("[reconcileLSCCreateFunc] Unable to reconcile the LocalStorageClass, name: %s", lsc.Name))
+		log.Error("the LocalStorageClass is invalid", logger.Err(err))
 		upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, msg)
 		if upError != nil {
-			log.Error(upError, fmt.Sprintf("[reconcileLSCCreateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 		}
 
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] successfully validated the LocalStorageClass, name: %s", lsc.Name))
+	log.Debug("the LocalStorageClass is valid")
 
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] starts storage class configuration for the LocalStorageClass, name: %s", lsc.Name))
+	log.Debug("building the StorageClass")
 	sc, err := configureStorageClass(lsc, effectiveLVGs, ignoredLabelPrefixes)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLSCCreateFunc] unable to configure Storage Class for LocalStorageClass, name: %s", lsc.Name))
+		log.Error("unable to build the StorageClass", logger.Err(err))
 		upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 		if upError != nil {
-			log.Error(upError, fmt.Sprintf("[reconcileLSCCreateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 			return true, upError
 		}
 		return false, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] successfully configurated storage class for the LocalStorageClass, name: %s", lsc.Name))
+	log.Debug("built the StorageClass")
 
 	created, err := createStorageClassIfNotExists(ctx, cl, scList, sc)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLSCCreateFunc] unable to create a Storage Class, name: %s", sc.Name))
+		log.Error("unable to create the StorageClass", logger.Err(err), slog.String("storageClass", sc.Name))
 		upError := updateLocalStorageClassPhase(ctx, cl, lsc, FailedStatusPhase, err.Error())
 		if upError != nil {
-			log.Error(upError, fmt.Sprintf("[reconcileLSCCreateFunc] unable to update the LocalStorageClass %s", lsc.Name))
+			log.Error("unable to update the LocalStorageClass status", logger.Err(upError))
 			return true, upError
 		}
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] a storage class %s was created: %t", sc.Name, created))
+	log.Debug("StorageClass creation result", "storageClass", sc.Name, "created", created)
 	if created {
-		log.Info(fmt.Sprintf("[reconcileLSCCreateFunc] successfully create storage class, name: %s", sc.Name))
+		log.Info("created the StorageClass", "storageClass", sc.Name)
 	} else {
-		log.Warning(fmt.Sprintf("[reconcileLSCCreateFunc] Storage class %s already exists. Adding event to requeue.", sc.Name))
+		log.Warn("the StorageClass already exists, requeueing", "storageClass", sc.Name)
 		return true, nil
 	}
 
 	added, err = addFinalizerIfNotExistsForSC(ctx, cl, sc)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLSCCreateFunc] unable to add a finalizer %s to the StorageClass %s", LocalStorageClassFinalizerName, sc.Name))
+		log.Error("unable to add the finalizer to the StorageClass", logger.Err(err), slog.String("finalizer", LocalStorageClassFinalizerName), slog.String("storageClass", sc.Name))
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] finalizer %s was added to the StorageClass %s: %t", LocalStorageClassFinalizerName, sc.Name, added))
+	log.Debug("StorageClass finalizer addition result", "finalizer", LocalStorageClassFinalizerName, "storageClass", sc.Name, "added", added)
 
 	err = updateLocalStorageClassPhase(ctx, cl, lsc, CreatedStatusPhase, "")
 	if err != nil {
-		log.Error(err, fmt.Sprintf("[reconcileLSCCreateFunc] unable to update the LocalStorageClass, name: %s", lsc.Name))
+		log.Error("unable to update the LocalStorageClass status", logger.Err(err))
 		return true, err
 	}
-	log.Debug(fmt.Sprintf("[reconcileLSCCreateFunc] successfully updated the LocalStorageClass %s status", sc.Name))
+	log.Debug("updated the LocalStorageClass status")
 
 	return false, nil
 }

--- a/images/controller/pkg/controller/local_storage_class_watcher_labels_test.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher_labels_test.go
@@ -26,7 +26,6 @@ import (
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-local-volume/images/controller/pkg/controller"
 	"github.com/deckhouse/sds-local-volume/images/controller/pkg/internal"
-	"github.com/deckhouse/sds-local-volume/images/controller/pkg/logger"
 )
 
 // defaultIgnoredPrefixes mirrors the union of the system list (internal values)
@@ -54,7 +53,7 @@ var _ = Describe("local-storage-class-controller label filtering", Ordered, func
 
 	var (
 		cl  client.Client
-		log = logger.NewLoggerFromLogr(GinkgoLogr)
+		log = NewTestLogger()
 
 		reclaimPolicy     = string(corev1.PersistentVolumeReclaimDelete)
 		volumeBindingMode = string(v1.VolumeBindingWaitForFirstConsumer)

--- a/images/controller/pkg/controller/local_storage_class_watcher_selector_more_test.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher_selector_more_test.go
@@ -26,7 +26,6 @@ import (
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-local-volume/images/controller/pkg/controller"
-	"github.com/deckhouse/sds-local-volume/images/controller/pkg/logger"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
 
@@ -44,7 +43,7 @@ var _ = Describe("local-storage-class-controller labelSelector (matchExpressions
 
 	var (
 		cl  client.Client
-		log = logger.NewLoggerFromLogr(GinkgoLogr)
+		log = NewTestLogger()
 
 		rp  = string(corev1.PersistentVolumeReclaimDelete)
 		vbm = string(v1.VolumeBindingWaitForFirstConsumer)

--- a/images/controller/pkg/controller/local_storage_class_watcher_selector_test.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher_selector_test.go
@@ -26,7 +26,6 @@ import (
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-local-volume/images/controller/pkg/controller"
-	"github.com/deckhouse/sds-local-volume/images/controller/pkg/logger"
 )
 
 var _ = Describe("local-storage-class-controller lvmVolumeGroups labelSelector", func() {
@@ -45,7 +44,7 @@ var _ = Describe("local-storage-class-controller lvmVolumeGroups labelSelector",
 
 	var (
 		cl  client.Client
-		log = logger.NewLoggerFromLogr(GinkgoLogr)
+		log = NewTestLogger()
 
 		reclaimPolicyDelete   = string(corev1.PersistentVolumeReclaimDelete)
 		volumeBindingModeWFFC = string(v1.VolumeBindingWaitForFirstConsumer)

--- a/images/controller/pkg/controller/local_storage_class_watcher_test.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher_test.go
@@ -31,7 +31,6 @@ import (
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-local-volume/images/controller/pkg/controller"
 	"github.com/deckhouse/sds-local-volume/images/controller/pkg/internal"
-	"github.com/deckhouse/sds-local-volume/images/controller/pkg/logger"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
 
@@ -55,7 +54,7 @@ var _ = Describe("local-storage-class-controller", Ordered, func() {
 
 	var (
 		cl  client.Client
-		log = logger.NewLoggerFromLogr(GinkgoLogr)
+		log = NewTestLogger()
 
 		reclaimPolicyDelete = string(corev1.PersistentVolumeReclaimDelete)
 		reclaimPolicyRetain = string(corev1.PersistentVolumeReclaimRetain)

--- a/images/controller/pkg/logger/logger.go
+++ b/images/controller/pkg/logger/logger.go
@@ -14,14 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package logger wraps github.com/deckhouse/deckhouse/pkg/log in the small API
-// this module uses.
+// Package logger adapts github.com/deckhouse/deckhouse/pkg/log to this module.
 //
-// The method set (Error/Warning/Info/Debug/Trace) is kept from the previous
-// klog-based implementation so that existing call sites are unaffected, and so
-// is the Verbosity type: LOG_LEVEL is delivered as a number 0..4 both by
-// lib-helm's helm_lib_module_controller_log_level and by the module's own CSI
-// templates, and that contract must not change.
+// Logger embeds *log.Logger rather than wrapping it, so Info/Debug/Warn/Error are
+// the library's own methods. That is deliberate: sloglint and govet's slog
+// analyzer only recognise log/slog and types embedding *slog.Logger, so
+// embedding is what puts every call site in the module under those checks. A
+// hand-written forwarding method would hide them again.
+//
+// Only what the library does not provide is added here: Verbosity parsing for the
+// numeric LOG_LEVEL contract, a Trace level, and Named/With overridden to return
+// this type.
+//
+// LOG_LEVEL is delivered as a number 0..4 both by lib-helm's
+// helm_lib_module_controller_log_level and by the module's own CSI templates, and
+// that contract must not change.
 package logger
 
 import (
@@ -81,55 +88,53 @@ func (v Verbosity) Level() (log.Level, error) {
 	}
 }
 
+// Logger is the module logger.
+//
+// The embedded pointer is what exposes Info, Debug, Warn and Error directly from
+// the library, and what makes those calls visible to the slog linters. Build one
+// with NewLogger, NewLoggerToWriter or NewNop; the zero value has no embedded
+// logger and panics on use.
 type Logger struct {
-	log *log.Logger
+	*log.Logger
 }
 
-// nop backs the zero Logger. The previous logr-based implementation held a
-// logr.Logger by value, whose zero value discards silently, and callers rely on
-// that: a zero Logger must stay a no-op rather than panic.
-var nop = log.NewNop()
-
-// unwrap returns the underlying logger, substituting the discard logger for a
-// zero Logger.
-func (l Logger) unwrap() *log.Logger {
-	if l.log == nil {
-		return nop
-	}
-	return l.log
-}
+// Err wraps an error into the field the library uses for it. Re-exported so that
+// a call site does not have to import pkg/log next to its own log variable:
+//
+//	log.Error("unable to create the volume", logger.Err(err))
+var Err = log.Err
 
 // NewLogger returns a logger emitting at the given verbosity.
-func NewLogger(level Verbosity) (*Logger, error) {
+func NewLogger(level Verbosity) (Logger, error) {
 	lvl, err := level.Level()
 	if err != nil {
-		return nil, err
+		return Logger{}, err
 	}
 
-	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()))}, nil
+	return Logger{log.NewLogger(log.WithLevel(lvl.Level()))}, nil
 }
 
 // NewLoggerToWriter returns a logger writing to w, for tests that want the
 // output attached to their own reporter.
-func NewLoggerToWriter(w io.Writer, level Verbosity) (*Logger, error) {
+func NewLoggerToWriter(w io.Writer, level Verbosity) (Logger, error) {
 	lvl, err := level.Level()
 	if err != nil {
-		return nil, err
+		return Logger{}, err
 	}
 
-	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()), log.WithOutput(w))}, nil
+	return Logger{log.NewLogger(log.WithLevel(lvl.Level()), log.WithOutput(w))}, nil
 }
 
 // NewNop returns a logger that discards everything, for tests that do not care
 // about log output.
-func NewNop() *Logger {
-	return &Logger{log: log.NewNop()}
+func NewNop() Logger {
+	return Logger{log.NewNop()}
 }
 
 // NewLoggerFromSlog adapts an existing pkg/log logger, so that a caller which
 // already built one does not have to reconfigure it.
 func NewLoggerFromSlog(l *log.Logger) Logger {
-	return Logger{log: l}
+	return Logger{l}
 }
 
 // Named appends name to the logger's dotted trace path, e.g. a logger named
@@ -137,92 +142,65 @@ func NewLoggerFromSlog(l *log.Logger) Logger {
 // "local-storage-class-controller.reconcile". Use it instead of hand-writing a
 // "[Component]" prefix into the message.
 func (l Logger) Named(name string) Logger {
-	return Logger{log: l.unwrap().Named(name)}
+	return Logger{l.Logger.Named(name)}
 }
 
 // With returns a logger that attaches the given key/value pairs to every
 // record. Use it for values that are constant for a unit of work, such as a
 // traceID or a volumeID, instead of interpolating them into each message.
 func (l Logger) With(args ...any) Logger {
-	return Logger{log: l.unwrap().With(args...)}
+	return Logger{l.Logger.With(args...)}
 }
 
-// SetLevel changes the emitted level in place, on every logger derived from this
-// one, without recreating it.
-func (l Logger) SetLevel(level Verbosity) error {
+// SetVerbosity changes the emitted level in place, on every logger derived from
+// this one, without recreating it.
+//
+// Named SetVerbosity rather than SetLevel so that it does not shadow the embedded
+// SetLevel, which takes a log.Level instead of the numeric Verbosity.
+func (l Logger) SetVerbosity(level Verbosity) error {
 	lvl, err := level.Level()
 	if err != nil {
 		return err
 	}
 
-	l.unwrap().SetLevel(lvl)
+	l.SetLevel(lvl)
 	return nil
 }
 
 // GetSlogLogger returns the underlying logger, for the few APIs that take one
 // directly.
 func (l Logger) GetSlogLogger() *log.Logger {
-	return l.unwrap()
+	return l.Logger
 }
 
 // GetLogger returns a logr view of this logger, for libraries that accept only
 // logr — controller-runtime's manager.Options.Logger in particular.
 func (l Logger) GetLogger() logr.Logger {
-	return logr.FromSlogHandler(l.unwrap().Handler())
-}
-
-// Error logs at error level. The error is attached as a structured field via
-// log.Err, and the underlying logger appends a full stack trace.
-//
-// This one delegates to the library instead of going through emit, because the
-// stack trace is injected by log.Logger.Error itself. The trace supersedes the
-// "source" field, which the handler drops when a trace is present, so nothing is
-// lost by not fixing up the caller frame here.
-func (l Logger) Error(err error, message string, keysAndValues ...interface{}) {
-	l.unwrap().Error(message, append([]any{log.Err(err)}, keysAndValues...)...)
-}
-
-func (l Logger) Warning(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelWarn, message, keysAndValues)
-}
-
-func (l Logger) Info(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelInfo, message, keysAndValues)
-}
-
-func (l Logger) Debug(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelDebug, message, keysAndValues)
+	return logr.FromSlogHandler(l.Handler())
 }
 
 // Trace logs at the trace level, which plain slog does not provide.
-func (l Logger) Trace(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelTrace, message, keysAndValues)
-}
-
-// emit builds the record by hand so that the "source" field names the call site
-// rather than this file.
 //
-// Calling log.Logger.Info and friends directly would make slog capture the
-// program counter of the wrapper, so every line would report
-// logger/logger.go. The previous klog-based logger avoided that with
-// WithCallDepth(1); this is the slog equivalent.
-func (l Logger) emit(level log.Level, message string, keysAndValues []any) {
-	lg := l.unwrap()
+// Info, Debug, Warn and Error come from the embedded logger, so slog attributes
+// them to their call site by itself. Trace is a method on this type, so the
+// record is built by hand to keep "source" pointing at the caller instead of this
+// file.
+func (l Logger) Trace(message string, args ...any) {
 	ctx := context.Background()
-	slevel := slog.Level(level)
+	level := slog.Level(log.LevelTrace)
 
-	if !lg.Enabled(ctx, slevel) {
+	if !l.Enabled(ctx, level) {
 		return
 	}
 
-	// Skip runtime.Callers, emit itself, and the exported method that called it.
+	// Skip runtime.Callers, Trace itself, and land on the caller.
 	var pcs [1]uintptr
-	runtime.Callers(3, pcs[:])
+	runtime.Callers(2, pcs[:])
 
-	record := slog.NewRecord(time.Now(), slevel, message, pcs[0])
-	record.Add(keysAndValues...)
+	record := slog.NewRecord(time.Now(), level, message, pcs[0])
+	record.Add(args...)
 
 	// The error is not actionable: the handler only fails if the record cannot be
 	// serialised, and there is nowhere left to report that.
-	_ = lg.Handler().Handle(ctx, record)
+	_ = l.Handler().Handle(ctx, record)
 }

--- a/images/controller/pkg/logger/logger_test.go
+++ b/images/controller/pkg/logger/logger_test.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"bytes"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -28,7 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-func newBufLogger(t *testing.T, level Verbosity) (*Logger, *bytes.Buffer) {
+func newBufLogger(t *testing.T, level Verbosity) (Logger, *bytes.Buffer) {
 	t.Helper()
 
 	buf := &bytes.Buffer{}
@@ -112,8 +113,8 @@ func TestLevelThresholds(t *testing.T) {
 		t.Run(string(tt.level), func(t *testing.T) {
 			l, buf := newBufLogger(t, tt.level)
 
-			l.Error(errors.New("boom"), "an-error")
-			l.Warning("a-warning")
+			l.Error("an-error", Err(errors.New("boom")))
+			l.Warn("a-warning")
 			l.Info("an-info")
 			l.Debug("a-debug")
 			l.Trace("a-trace")
@@ -132,7 +133,7 @@ func TestLevelThresholds(t *testing.T) {
 func TestErrorAttachesErrorAndStackTrace(t *testing.T) {
 	l, buf := newBufLogger(t, TraceLevel)
 
-	l.Error(errors.New("disk on fire"), "unable to create volume", "volumeID", "pvc-123")
+	l.Error("unable to create volume", Err(errors.New("disk on fire")), slog.String("volumeID", "pvc-123"))
 
 	out := buf.String()
 	assert.Contains(t, out, "unable to create volume")
@@ -149,7 +150,7 @@ func TestErrorToleratesNilError(t *testing.T) {
 
 	// Call sites pass whatever they hold; a nil error must not panic.
 	assert.NotPanics(t, func() {
-		l.Error(nil, "something went wrong")
+		l.Error("something went wrong", Err(nil))
 	})
 	assert.Contains(t, buf.String(), "something went wrong")
 }
@@ -196,7 +197,7 @@ func TestSetLevelChangesLevelInPlace(t *testing.T) {
 
 	// Changing the level must affect the live logger, which is what lets the
 	// level be raised without restarting the pod.
-	require.NoError(t, l.SetLevel(DebugLevel))
+	require.NoError(t, l.SetVerbosity(DebugLevel))
 	l.Debug("after")
 	assert.Contains(t, buf.String(), "after")
 }
@@ -208,7 +209,7 @@ func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
 	child.Debug("before")
 	require.NotContains(t, buf.String(), "before")
 
-	require.NoError(t, l.SetLevel(DebugLevel))
+	require.NoError(t, l.SetVerbosity(DebugLevel))
 
 	child.Debug("after")
 	assert.Contains(t, buf.String(), "after")
@@ -216,51 +217,51 @@ func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
 
 func TestSetLevelRejectsInvalidValue(t *testing.T) {
 	l, _ := newBufLogger(t, InfoLevel)
-	assert.Error(t, l.SetLevel(Verbosity("nonsense")))
+	assert.Error(t, l.SetVerbosity(Verbosity("nonsense")))
 }
 
 func TestNopDiscardsEverything(t *testing.T) {
 	l := NewNop()
 
 	assert.NotPanics(t, func() {
-		l.Error(errors.New("boom"), "an-error")
+		l.Error("an-error", Err(errors.New("boom")))
 		l.Info("an-info")
 		l.Trace("a-trace")
 		l.Named("x").With("k", "v").Debug("a-debug")
 	})
 }
 
-// TestZeroLoggerIsANoOp guards the behaviour the previous logr-backed
-// implementation had: tests construct logger.Logger{} directly and must not
-// crash on it.
-func TestZeroLoggerIsANoOp(t *testing.T) {
-	var l Logger
+// TestNopIsUsableEverywhere covers what the zero value used to be relied on for.
+// Embedding *log.Logger means the zero Logger can no longer be a silent no-op, so
+// callers that want one ask for NewNop instead.
+func TestNopIsUsableEverywhere(t *testing.T) {
+	l := NewNop()
 
 	assert.NotPanics(t, func() {
-		l.Error(errors.New("boom"), "an-error")
-		l.Warning("a-warning")
+		l.Error("an-error", Err(errors.New("boom")))
+		l.Warn("a-warning")
 		l.Info("an-info")
 		l.Debug("a-debug")
 		l.Trace("a-trace")
 		l.Named("x").With("k", "v").Info("nested")
 		_ = l.GetLogger()
 		_ = l.GetSlogLogger()
-		_ = l.SetLevel(InfoLevel)
+		_ = l.SetVerbosity(InfoLevel)
 	})
 }
 
-// TestSourceNamesTheCallSite guards against the wrapper attributing every record
-// to itself. Without the manual record construction in emit, "source" would read
-// logger/logger.go for all 300-odd call sites in the module.
+// TestSourceNamesTheCallSite guards caller attribution. Info/Debug/Warn come
+// straight from the embedded logger so slog attributes them itself; Trace is a
+// method on this type and builds its record by hand to achieve the same.
 func TestSourceNamesTheCallSite(t *testing.T) {
 	tests := []struct {
 		name string
-		emit func(l *Logger)
+		emit func(l Logger)
 	}{
-		{name: "Warning", emit: func(l *Logger) { l.Warning("m") }},
-		{name: "Info", emit: func(l *Logger) { l.Info("m") }},
-		{name: "Debug", emit: func(l *Logger) { l.Debug("m") }},
-		{name: "Trace", emit: func(l *Logger) { l.Trace("m") }},
+		{name: "Warn", emit: func(l Logger) { l.Warn("m") }},
+		{name: "Info", emit: func(l Logger) { l.Info("m") }},
+		{name: "Debug", emit: func(l Logger) { l.Debug("m") }},
+		{name: "Trace", emit: func(l Logger) { l.Trace("m") }},
 	}
 
 	for _, tt := range tests {
@@ -282,7 +283,7 @@ func TestSourceNamesTheCallSite(t *testing.T) {
 func TestErrorReportsStackTraceInsteadOfSource(t *testing.T) {
 	l, buf := newBufLogger(t, TraceLevel)
 
-	l.Error(errors.New("boom"), "failed")
+	l.Error("failed", Err(errors.New("boom")))
 
 	out := buf.String()
 	assert.NotContains(t, out, `"source"`)

--- a/images/controller/pkg/logger/logger_test.go
+++ b/images/controller/pkg/logger/logger_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+func newBufLogger(t *testing.T, level Verbosity) (*Logger, *bytes.Buffer) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	l, err := NewLoggerToWriter(buf, level)
+	require.NoError(t, err)
+	return l, buf
+}
+
+func TestVerbosityLevelMapping(t *testing.T) {
+	// The numeric LOG_LEVEL contract is shared with lib-helm and the CSI
+	// templates; these thresholds must keep matching the previous klog-based
+	// logger, where Warning was V(1), Info V(2), Debug V(3) and Trace V(4).
+	tests := []struct {
+		verbosity Verbosity
+		want      log.Level
+	}{
+		{verbosity: ErrorLevel, want: log.LevelError},
+		{verbosity: WarningLevel, want: log.LevelWarn},
+		{verbosity: InfoLevel, want: log.LevelInfo},
+		{verbosity: DebugLevel, want: log.LevelDebug},
+		{verbosity: TraceLevel, want: log.LevelTrace},
+		// Anything past TRACE stays at TRACE, as before.
+		{verbosity: Verbosity("9"), want: log.LevelTrace},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.verbosity), func(t *testing.T) {
+			got, err := tt.verbosity.Level()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVerbosityRejectsInvalidValues(t *testing.T) {
+	for _, v := range []Verbosity{"", "abc", "-1", "2.5"} {
+		t.Run(string(v), func(t *testing.T) {
+			_, err := v.Level()
+			assert.Error(t, err)
+
+			_, err = NewLogger(v)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestLevelThresholds pins which methods emit at each configured verbosity.
+func TestLevelThresholds(t *testing.T) {
+	tests := []struct {
+		level   Verbosity
+		emitted []string
+		dropped []string
+	}{
+		{
+			level:   ErrorLevel,
+			emitted: []string{"an-error"},
+			dropped: []string{"a-warning", "an-info", "a-debug", "a-trace"},
+		},
+		{
+			level:   WarningLevel,
+			emitted: []string{"an-error", "a-warning"},
+			dropped: []string{"an-info", "a-debug", "a-trace"},
+		},
+		{
+			level:   InfoLevel,
+			emitted: []string{"an-error", "a-warning", "an-info"},
+			dropped: []string{"a-debug", "a-trace"},
+		},
+		{
+			level:   DebugLevel,
+			emitted: []string{"an-error", "a-warning", "an-info", "a-debug"},
+			dropped: []string{"a-trace"},
+		},
+		{
+			level:   TraceLevel,
+			emitted: []string{"an-error", "a-warning", "an-info", "a-debug", "a-trace"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.level), func(t *testing.T) {
+			l, buf := newBufLogger(t, tt.level)
+
+			l.Error(errors.New("boom"), "an-error")
+			l.Warning("a-warning")
+			l.Info("an-info")
+			l.Debug("a-debug")
+			l.Trace("a-trace")
+
+			out := buf.String()
+			for _, msg := range tt.emitted {
+				assert.Contains(t, out, msg, "%s should be emitted at %s", msg, tt.level)
+			}
+			for _, msg := range tt.dropped {
+				assert.NotContains(t, out, msg, "%s should be dropped at %s", msg, tt.level)
+			}
+		})
+	}
+}
+
+func TestErrorAttachesErrorAndStackTrace(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Error(errors.New("disk on fire"), "unable to create volume", "volumeID", "pvc-123")
+
+	out := buf.String()
+	assert.Contains(t, out, "unable to create volume")
+	// The error travels as a structured field rather than being interpolated
+	// into the message.
+	assert.Contains(t, out, "disk on fire")
+	assert.Contains(t, out, "pvc-123")
+	// A stack trace is what the previous logger did not provide.
+	assert.Contains(t, out, "logger.TestErrorAttachesErrorAndStackTrace")
+}
+
+func TestErrorToleratesNilError(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	// Call sites pass whatever they hold; a nil error must not panic.
+	assert.NotPanics(t, func() {
+		l.Error(nil, "something went wrong")
+	})
+	assert.Contains(t, buf.String(), "something went wrong")
+}
+
+func TestNamedBuildsDottedPath(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Named("local-storage-class-controller").Named("reconcile").Info("starting")
+
+	// This is the replacement for hand-written "[Component]" message prefixes.
+	assert.Contains(t, buf.String(), "local-storage-class-controller.reconcile")
+}
+
+func TestNamedDoesNotAffectTheParent(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	child := l.Named("child")
+	child.Info("from-child")
+	l.Info("from-parent")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "child")
+	assert.NotContains(t, lines[1], "child")
+}
+
+func TestWithAttachesFieldsToEveryRecord(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	scoped := l.With("traceID", "abc-123", "volumeID", "pvc-1")
+	scoped.Info("first")
+	scoped.Trace("second")
+
+	out := buf.String()
+	assert.Equal(t, 2, strings.Count(out, "abc-123"))
+	assert.Equal(t, 2, strings.Count(out, "pvc-1"))
+}
+
+func TestSetLevelChangesLevelInPlace(t *testing.T) {
+	l, buf := newBufLogger(t, ErrorLevel)
+
+	l.Debug("before")
+	require.NotContains(t, buf.String(), "before")
+
+	// Changing the level must affect the live logger, which is what lets the
+	// level be raised without restarting the pod.
+	require.NoError(t, l.SetLevel(DebugLevel))
+	l.Debug("after")
+	assert.Contains(t, buf.String(), "after")
+}
+
+func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
+	l, buf := newBufLogger(t, ErrorLevel)
+	child := l.Named("child").With("k", "v")
+
+	child.Debug("before")
+	require.NotContains(t, buf.String(), "before")
+
+	require.NoError(t, l.SetLevel(DebugLevel))
+
+	child.Debug("after")
+	assert.Contains(t, buf.String(), "after")
+}
+
+func TestSetLevelRejectsInvalidValue(t *testing.T) {
+	l, _ := newBufLogger(t, InfoLevel)
+	assert.Error(t, l.SetLevel(Verbosity("nonsense")))
+}
+
+func TestNopDiscardsEverything(t *testing.T) {
+	l := NewNop()
+
+	assert.NotPanics(t, func() {
+		l.Error(errors.New("boom"), "an-error")
+		l.Info("an-info")
+		l.Trace("a-trace")
+		l.Named("x").With("k", "v").Debug("a-debug")
+	})
+}
+
+// TestZeroLoggerIsANoOp guards the behaviour the previous logr-backed
+// implementation had: tests construct logger.Logger{} directly and must not
+// crash on it.
+func TestZeroLoggerIsANoOp(t *testing.T) {
+	var l Logger
+
+	assert.NotPanics(t, func() {
+		l.Error(errors.New("boom"), "an-error")
+		l.Warning("a-warning")
+		l.Info("an-info")
+		l.Debug("a-debug")
+		l.Trace("a-trace")
+		l.Named("x").With("k", "v").Info("nested")
+		_ = l.GetLogger()
+		_ = l.GetSlogLogger()
+		_ = l.SetLevel(InfoLevel)
+	})
+}
+
+// TestSourceNamesTheCallSite guards against the wrapper attributing every record
+// to itself. Without the manual record construction in emit, "source" would read
+// logger/logger.go for all 300-odd call sites in the module.
+func TestSourceNamesTheCallSite(t *testing.T) {
+	tests := []struct {
+		name string
+		emit func(l *Logger)
+	}{
+		{name: "Warning", emit: func(l *Logger) { l.Warning("m") }},
+		{name: "Info", emit: func(l *Logger) { l.Info("m") }},
+		{name: "Debug", emit: func(l *Logger) { l.Debug("m") }},
+		{name: "Trace", emit: func(l *Logger) { l.Trace("m") }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, buf := newBufLogger(t, TraceLevel)
+
+			tt.emit(l)
+
+			out := buf.String()
+			assert.Contains(t, out, "logger_test.go")
+			assert.NotContains(t, out, "logger/logger.go")
+		})
+	}
+}
+
+// TestErrorReportsStackTraceInsteadOfSource documents the one exception: the
+// handler drops "source" when a stack trace is attached, so Error does not need
+// caller fix-up.
+func TestErrorReportsStackTraceInsteadOfSource(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Error(errors.New("boom"), "failed")
+
+	out := buf.String()
+	assert.NotContains(t, out, `"source"`)
+	assert.Contains(t, out, "stacktrace")
+}
+
+func TestGetLoggerBridgesToLogr(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	// controller-runtime takes a logr.Logger; records written through it must
+	// land in the same output with the same level handling.
+	l.GetLogger().Info("from-logr", "k", "v")
+
+	out := buf.String()
+	assert.Contains(t, out, "from-logr")
+	assert.Contains(t, out, "\"k\":\"v\"")
+}

--- a/images/controller/test/integration/suite_test.go
+++ b/images/controller/test/integration/suite_test.go
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 	}
 	// The zero Recorder discards every observation, so the suite does not need a
 	// metrics registry to exercise the reconcile behaviour.
-	_, err = controller.RunLocalStorageClassWatcherController(mgr, cfgParams, *suiteLog, monitoring.Recorder{})
+	_, err = controller.RunLocalStorageClassWatcherController(mgr, cfgParams, suiteLog, monitoring.Recorder{})
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/images/controller/test/integration/suite_test.go
+++ b/images/controller/test/integration/suite_test.go
@@ -42,7 +42,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
@@ -71,7 +70,12 @@ func TestIntegration(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+	// Route controller-runtime's own logging through the module logger too, so the
+	// suite exercises the same stack the controller uses in production.
+	suiteLog, err := logger.NewLoggerToWriter(GinkgoWriter, logger.TraceLevel)
+	Expect(err).NotTo(HaveOccurred())
+	ctrl.SetLogger(suiteLog.GetLogger())
+
 	suiteCtx, suiteCancel = context.WithCancel(context.Background())
 
 	testEnv = &envtest.Environment{
@@ -85,7 +89,6 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	var err error
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -109,7 +112,6 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	log := logger.NewLoggerFromLogr(GinkgoLogr)
 	cfgParams := config.Options{
 		ControllerNamespace:         controllerNamespace,
 		ConfigSecretName:            config.ConfigSecretName,
@@ -117,7 +119,7 @@ var _ = BeforeSuite(func() {
 	}
 	// The zero Recorder discards every observation, so the suite does not need a
 	// metrics registry to exercise the reconcile behaviour.
-	_, err = controller.RunLocalStorageClassWatcherController(mgr, cfgParams, log, monitoring.Recorder{})
+	_, err = controller.RunLocalStorageClassWatcherController(mgr, cfgParams, *suiteLog, monitoring.Recorder{})
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/images/sds-local-volume-csi/cmd/main.go
+++ b/images/sds-local-volume-csi/cmd/main.go
@@ -76,24 +76,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("version = ", cfgParams.Version)
+	log.Info("starting sds-local-volume-csi", "version", cfgParams.Version)
 
 	kConfig, err := kubutils.KubernetesDefaultConfigCreate()
 	if err != nil {
-		log.Error(err, "[main] unable to KubernetesDefaultConfigCreate")
+		log.Error("unable to KubernetesDefaultConfigCreate", logger.Err(err))
 		os.Exit(1)
 	}
-	log.Info("[main] kubernetes config has been successfully created.")
+	log.Info("kubernetes config has been successfully created.")
 
 	scheme := apiruntime.NewScheme()
 	for _, f := range resourcesSchemeFuncs {
 		err := f(scheme)
 		if err != nil {
-			log.Error(err, "[main] unable to add scheme to func")
+			log.Error("unable to add scheme to func", logger.Err(err))
 			os.Exit(1)
 		}
 	}
-	log.Info("[main] successfully read scheme CR")
+	log.Info("successfully read scheme CR")
 
 	cl, err := client.New(kConfig, client.Options{
 		Scheme: scheme,
@@ -104,7 +104,7 @@ func main() {
 	go func() {
 		err = http.ListenAndServe(cfgParams.HealthProbeBindAddress, nil)
 		if err != nil {
-			log.Error(err, "[main] create probes")
+			log.Error("create probes", logger.Err(err))
 		}
 	}()
 
@@ -113,21 +113,21 @@ func main() {
 	// default one used by the health probes above.
 	metricStorage := metricsstorage.NewMetricStorage(metricsstorage.WithNewRegistry())
 	if err = monitoring.Register(metricStorage); err != nil {
-		log.Error(err, "[main] unable to register metrics")
+		log.Error("unable to register the metrics", logger.Err(err))
 		os.Exit(1)
 	}
 	go func() {
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("/metrics", metricStorage.Handler())
 		if err := http.ListenAndServe(cfgParams.MetricsBindAddress, metricsMux); err != nil {
-			log.Error(err, "[main] serve metrics")
+			log.Error("unable to serve the metrics", logger.Err(err))
 		}
 	}()
-	log.Info(fmt.Sprintf("[main] metrics are registered and served on %s/metrics", cfgParams.MetricsBindAddress))
+	log.Info("metrics registered", "address", cfgParams.MetricsBindAddress+"/metrics")
 
 	drv, err := driver.NewDriver(cfgParams.CsiAddress, cfgParams.DriverName, cfgParams.Address, &cfgParams.NodeName, log, monitoring.NewRecorder(metricStorage), cl)
 	if err != nil {
-		log.Error(err, "[main] create NewDriver")
+		log.Error("create NewDriver", logger.Err(err))
 	}
 
 	defer cancel()
@@ -140,6 +140,6 @@ func main() {
 	}()
 
 	if err := drv.Run(ctx); err != nil {
-		log.Error(err, "[dev.Run]")
+		log.Error("[dev.Run]", logger.Err(err))
 	}
 }

--- a/images/sds-local-volume-csi/driver/controller.go
+++ b/images/sds-local-volume-csi/driver/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/google/uuid"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/internal"
+	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/pkg/logger"
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/pkg/utils"
 	"github.com/deckhouse/sds-local-volume/lib/go/common/pkg/feature"
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
@@ -47,10 +49,10 @@ const (
 //
 // The returned error is already a gRPC status and is meant to be handed straight
 // back to the caller of the RPC.
-func (d *Driver) alignToLVGExtentOrStatusErr(traceID, volumeID string, size resource.Quantity, lvg *v1alpha1.LVMVolumeGroup) (resource.Quantity, error) {
+func alignToLVGExtentOrStatusErr(log logger.Logger, size resource.Quantity, lvg *v1alpha1.LVMVolumeGroup) (resource.Quantity, error) {
 	aligned, err := utils.AlignSizeToExtent(size, utils.SafeExtentSize(lvg.Status.ExtentSize))
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[traceID:%s][volumeID:%s] error aligning size to extent", traceID, volumeID))
+		log.Error("unable to align the size to the LVM extent", logger.Err(err), slog.String("size", size.String()))
 		return resource.Quantity{}, status.Errorf(codes.Internal, "error aligning size to extent: %s", err.Error())
 	}
 
@@ -99,9 +101,11 @@ func resolveCapacityBytes(llv *v1alpha1.LVMLogicalVolume, fallback resource.Quan
 func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	traceID := uuid.New().String()
 
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s] ========== CreateVolume ============", traceID))
-	d.log.Trace(request.String())
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s] ========== CreateVolume ============", traceID))
+	// Named + With replace the "[CreateVolume][traceID:...][volumeID:...]" prefix
+	// that used to be interpolated into every message of this RPC.
+	log := d.log.Named("CreateVolume").With("traceID", traceID)
+
+	log.Trace("start", "request", request.String())
 
 	if request.Parameters[internal.TypeKey] != internal.Lvm {
 		return nil, status.Error(codes.InvalidArgument, "Unsupported Storage Class type")
@@ -115,26 +119,30 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		return nil, status.Error(codes.InvalidArgument, "Volume Capability cannot de empty")
 	}
 
+	// volumeID is only known once the request has been validated, so it joins the
+	// logger here rather than above.
+	log = log.With("volumeID", volumeID)
+
 	BindingMode := request.Parameters[internal.BindingModeKey]
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] storage class BindingMode: %s", traceID, volumeID, BindingMode))
+	log.Info("storage class binding mode", "bindingMode", BindingMode)
 
 	LvmType := request.Parameters[internal.LvmTypeKey]
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] storage class LvmType: %s", traceID, volumeID, LvmType))
+	log.Info("storage class LVM type", "lvmType", LvmType)
 
 	if len(request.Parameters[internal.LVMVolumeGroupKey]) == 0 {
 		err := errors.New("no LVMVolumeGroups specified in a storage class's parameters")
-		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] no LVMVolumeGroups were found for the request: %+v", traceID, volumeID, request))
+		log.Error("no LVMVolumeGroups were found for the request", logger.Err(err), slog.String("request", request.String()))
 		return nil, status.Errorf(codes.InvalidArgument, "no LVMVolumeGroups specified in a storage class's parameters")
 	}
 
-	storageClassLVGs, storageClassLVGParametersMap, err := utils.GetStorageClassLVGsAndParameters(ctx, d.cl, d.log, request.Parameters[internal.LVMVolumeGroupKey])
+	storageClassLVGs, storageClassLVGParametersMap, err := utils.GetStorageClassLVGsAndParameters(ctx, d.cl, log, request.Parameters[internal.LVMVolumeGroupKey])
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error GetStorageClassLVGs", traceID, volumeID))
+		log.Error("unable to get the storage class LVMVolumeGroups", logger.Err(err))
 		return nil, status.Errorf(codes.Internal, "error during GetStorageClassLVGs")
 	}
 
 	contiguous := utils.IsContiguous(request, LvmType)
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] contiguous: %t", traceID, volumeID, contiguous))
+	log.Info("resolved contiguous", "contiguous", contiguous)
 
 	// TODO: Consider refactoring the naming strategy for llvName and lvName.
 	// Currently, we use the same name for llvName (the name of the LVMLogicalVolume resource in Kubernetes)
@@ -144,10 +152,10 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 	// code readability and maintainability.
 	llvName := volumeID
 	lvName := volumeID
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] llv name: %s", traceID, volumeID, llvName))
+	log.Info("resolved LVMLogicalVolume name", "llvName", llvName)
 
 	llvSize := resource.NewQuantity(request.CapacityRange.GetRequiredBytes(), resource.BinarySI)
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] llv size: %s", traceID, volumeID, llvSize.String()))
+	log.Info("resolved LVMLogicalVolume size", "llvSize", llvSize.String())
 
 	var selectedLVG *v1alpha1.LVMVolumeGroup
 	var preferredNode string
@@ -161,7 +169,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		// turn that into a synchronous error.
 		if LvmType != internal.LVMTypeThin {
 			err := fmt.Errorf("volume content source is supported for %s volumes only, got %s", internal.LVMTypeThin, LvmType)
-			d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] unsupported LvmType for a volume with a content source", traceID, volumeID))
+			log.Error("unsupported LVM type for a volume with a content source", logger.Err(err), slog.String("lvmType", LvmType))
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 
@@ -173,38 +181,30 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 			sourceVol, err := utils.GetLVMLogicalVolumeSnapshot(ctx, d.cl, sourceVolume.Name, "")
 			if err != nil {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error getting source LVMLogicalVolumeSnapshot", traceID, sourceVolume.Name))
+				log.Error("unable to get the source LVMLogicalVolumeSnapshot", logger.Err(err), slog.String("sourceName", sourceVolume.Name))
 				return nil, status.Errorf(codes.NotFound, "error getting LVMLogicalVolumeSnapshot %s: %s", sourceVolume.Name, err.Error())
 			}
 
 			if sourceVol.Status == nil || sourceVol.Status.Phase != internal.LLVSStatusCreated {
-				d.log.Error(nil, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] source LVMLogicalVolumeSnapshot is not in Created phase", traceID, sourceVolume.Name))
+				log.Error("the source LVMLogicalVolumeSnapshot is not in the Created phase", slog.String("sourceName", sourceVolume.Name))
 				return nil, status.Errorf(codes.FailedPrecondition, "LVMLogicalVolumeSnapshot %s is not in Created phase", sourceVolume.Name)
 			}
 
 			selectedLVG, err = utils.SelectLVGByActualNameOnTheNode(storageClassLVGs, sourceVol.Status.NodeName, sourceVol.Status.ActualVGNameOnTheNode)
 			if err != nil {
-				d.log.Error(
-					err,
-					fmt.Sprintf(
-						"[CreateVolume][traceID:%s] source LVMVolumeGroup %s from node %s is not found in storage class LVGs",
-						traceID,
-						sourceVol.Status.ActualVGNameOnTheNode,
-						sourceVol.Status.NodeName,
-					),
-				)
+				log.Error("the source LVMVolumeGroup is not among the storage class LVMVolumeGroups", logger.Err(err), slog.String("vgName", sourceVol.Status.ActualVGNameOnTheNode), slog.String("nodeName", sourceVol.Status.NodeName))
 				return nil, status.Errorf(codes.FailedPrecondition, "error getting LVMVolumeGroup %s: %s", sourceVol.Status.ActualVGNameOnTheNode, err.Error())
 			}
 
 			if _, ok := storageClassLVGParametersMap[selectedLVG.Name]; !ok {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] should use the same storage class as source", traceID, volumeID))
+				log.Error("the volume must use the same storage class as its source", slog.String("lvgName", selectedLVG.Name))
 				return nil, status.Errorf(codes.InvalidArgument, "should use the same storage class as source")
 			}
 
 			if llvSize.Value() == 0 {
 				*llvSize = sourceVol.Status.Size
 			} else {
-				alignedLlvSize, alignErr := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *llvSize, selectedLVG)
+				alignedLlvSize, alignErr := alignToLVGExtentOrStatusErr(log, *llvSize, selectedLVG)
 				if alignErr != nil {
 					return nil, alignErr
 				}
@@ -221,7 +221,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 			sourceVol, err := utils.GetLVMLogicalVolume(ctx, d.cl, sourceVolume.Name, "")
 			if err != nil {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error getting source LVMLogicalVolume", traceID, sourceVolume.Name))
+				log.Error("unable to get the source LVMLogicalVolume", logger.Err(err), slog.String("sourceName", sourceVolume.Name))
 				return nil, status.Errorf(codes.NotFound, "error getting LVMLogicalVolume %s: %s", sourceVolume.Name, err.Error())
 			}
 
@@ -231,25 +231,25 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 			sourceSizeQty, err := resource.ParseQuantity(sourceVol.Spec.Size)
 			if err != nil {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s] error parsing quantity %s", traceID, sourceVol.Spec.Size))
+				log.Error("unable to parse the source volume size", logger.Err(err), slog.String("size", sourceVol.Spec.Size))
 				return nil, status.Errorf(codes.Internal, "error parsing quantity: %v", err)
 			}
 
 			selectedLVG, err = utils.SelectLVGByName(storageClassLVGs, sourceVol.Spec.LVMVolumeGroupName)
 			if err != nil {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s] error getting LVMVolumeGroup %s", traceID, sourceVol.Spec.LVMVolumeGroupName))
+				log.Error("unable to select the LVMVolumeGroup by name", logger.Err(err), slog.String("lvgName", sourceVol.Spec.LVMVolumeGroupName))
 				return nil, status.Errorf(codes.Internal, "error getting LVMVolumeGroup %s: %s", sourceVol.Spec.LVMVolumeGroupName, err.Error())
 			}
 
 			if _, ok := storageClassLVGParametersMap[selectedLVG.Name]; !ok {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] should use the same storage class as source", traceID, volumeID))
+				log.Error("the volume must use the same storage class as its source", slog.String("lvgName", selectedLVG.Name))
 				return nil, status.Errorf(codes.InvalidArgument, "should use the same storage class as source")
 			}
 
 			if llvSize.Value() == 0 {
 				*llvSize = sourceSizeQty
 			} else {
-				alignedLlvSize, alignErr := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *llvSize, selectedLVG)
+				alignedLlvSize, alignErr := alignToLVGExtentOrStatusErr(log, *llvSize, selectedLVG)
 				if alignErr != nil {
 					return nil, alignErr
 				}
@@ -269,29 +269,29 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 		switch BindingMode {
 		case internal.BindingModeI:
-			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] BindingMode is %s. Start selecting node", traceID, volumeID, internal.BindingModeI))
+			log.Info("immediate binding, selecting a node", "bindingMode", internal.BindingModeI)
 			selectedNodeName, freeSpace, err := utils.GetNodeWithMaxFreeSpace(storageClassLVGs, storageClassLVGParametersMap, LvmType)
 			if err != nil {
-				d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error GetNodeWithMaxFreeSpace", traceID, volumeID))
+				log.Error("unable to select the node with the most free space", logger.Err(err))
 				return nil, status.Errorf(codes.Internal, "error selecting the node with max free space: %s", err.Error())
 			}
 
 			preferredNode = selectedNodeName
 			maxFreeSpace = freeSpace
-			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] Selected node: %s, free space %s", traceID, volumeID, selectedNodeName, freeSpace.String()))
+			log.Info("selected a node", "nodeName", selectedNodeName, "freeSpace", freeSpace.String())
 		case internal.BindingModeWFFC:
-			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] BindingMode is %s. Get preferredNode", traceID, volumeID, internal.BindingModeWFFC))
+			log.Info("late binding, taking the preferred node from the request", "bindingMode", internal.BindingModeWFFC)
 			if len(request.AccessibilityRequirements.Preferred) != 0 {
 				t := request.AccessibilityRequirements.Preferred[0].Segments
 				preferredNode = t[internal.TopologyKey]
 			}
 		}
 
-		d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] preferredNode: %s. Select LVG", traceID, volumeID, preferredNode))
+		log.Trace("selecting an LVMVolumeGroup", "preferredNode", preferredNode)
 		selectedLVG, err = utils.SelectLVG(storageClassLVGs, preferredNode)
-		d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] selectedLVG: %+v", traceID, volumeID, selectedLVG))
+		log.Info("selected an LVMVolumeGroup", "lvg", fmt.Sprintf("%+v", selectedLVG))
 		if err != nil {
-			d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error SelectLVG", traceID, volumeID))
+			log.Error("unable to select an LVMVolumeGroup", logger.Err(err), slog.String("preferredNode", preferredNode))
 			return nil, status.Errorf(codes.Internal, "error during SelectLVG")
 		}
 
@@ -300,7 +300,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		// snapshot/volume content-source branches above already align; without this
 		// the plain path stores an unaligned size (e.g. 35Mi) that drifts from the
 		// extent-rounded LV on the node.
-		alignedLlvSize, alignErr := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *llvSize, selectedLVG)
+		alignedLlvSize, alignErr := alignToLVGExtentOrStatusErr(log, *llvSize, selectedLVG)
 		if alignErr != nil {
 			return nil, alignErr
 		}
@@ -317,7 +317,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 	}
 
 	llvSpec := utils.GetLLVSpec(
-		d.log,
+		log,
 		lvName,
 		*selectedLVG,
 		storageClassLVGParametersMap,
@@ -328,39 +328,39 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		volumeCleanup,
 	)
 
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] LVMLogicalVolumeSpec: %+v", traceID, volumeID, llvSpec))
+	log.Info("built the LVMLogicalVolume spec", "spec", fmt.Sprintf("%+v", llvSpec))
 
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ------------ CreateLVMLogicalVolume start ------------", traceID, volumeID))
-	_, err = utils.CreateLVMLogicalVolume(ctx, d.cl, d.log, traceID, llvName, llvSpec)
+	log.Trace("creating the LVMLogicalVolume")
+	_, err = utils.CreateLVMLogicalVolume(ctx, d.cl, log, llvName, llvSpec)
 	if err != nil {
 		if kerrors.IsAlreadyExists(err) {
-			d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] LVMLogicalVolume %s already exists. Skip creating", traceID, volumeID, llvName))
+			log.Info("the LVMLogicalVolume already exists, skipping creation", "llvName", llvName)
 		} else {
-			d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error CreateLVMLogicalVolume", traceID, volumeID))
+			log.Error("unable to create the LVMLogicalVolume", logger.Err(err), slog.String("llvName", llvName))
 			return nil, err
 		}
 	}
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] ------------ CreateLVMLogicalVolume end ------------", traceID, volumeID))
+	log.Trace("created the LVMLogicalVolume")
 
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] start wait CreateLVMLogicalVolume", traceID, volumeID))
+	log.Trace("waiting for the LVMLogicalVolume status")
 
-	createdLLV, attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, d.log, traceID, request.Name, "", *llvSize, utils.SafeExtentSize(selectedLVG.Status.ExtentSize))
+	createdLLV, attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, log, request.Name, "", *llvSize, utils.SafeExtentSize(selectedLVG.Status.ExtentSize))
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error WaitForStatusUpdate. Delete LVMLogicalVolume %s", traceID, volumeID, request.Name))
+		log.Error("the LVMLogicalVolume did not become ready, deleting it", logger.Err(err), slog.String("llvName", request.Name))
 
-		deleteErr := utils.DeleteLVMLogicalVolume(ctx, d.cl, d.log, traceID, request.Name, volumeCleanup)
+		deleteErr := utils.DeleteLVMLogicalVolume(ctx, d.cl, log, request.Name, volumeCleanup)
 		if deleteErr != nil {
-			d.log.Error(deleteErr, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error DeleteLVMLogicalVolume", traceID, volumeID))
+			log.Error("unable to delete the LVMLogicalVolume after a failed wait", logger.Err(deleteErr), slog.String("llvName", request.Name))
 		}
 
-		d.log.Error(err, fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] error creating LVMLogicalVolume", traceID, volumeID))
+		log.Error("unable to create the volume", logger.Err(err))
 		return nil, err
 	}
-	d.log.Trace(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] finish wait CreateLVMLogicalVolume, attempt counter = %d", traceID, volumeID, attemptCounter))
+	log.Trace("the LVMLogicalVolume became ready", "attempts", attemptCounter)
 
 	capacityBytes, fromStatus := resolveCapacityBytes(createdLLV, *llvSize)
 	if !fromStatus {
-		d.log.Warning(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] LVMLogicalVolume %s has no status after a successful wait, reporting the aligned requested size %s", traceID, volumeID, request.Name, llvSize.String()))
+		log.Warn("the LVMLogicalVolume has no status after a successful wait, reporting the aligned requested size", "llvName", request.Name, "alignedSize", llvSize.String())
 	}
 
 	volumeCtx := make(map[string]string, len(request.Parameters))
@@ -376,7 +376,7 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 		volumeCtx[internal.ThinPoolNameKey] = ""
 	}
 
-	d.log.Info(fmt.Sprintf("[CreateVolume][traceID:%s][volumeID:%s] Volume created successfully. volumeCtx: %+v", traceID, volumeID, volumeCtx))
+	log.Info("volume created successfully", "volumeContext", fmt.Sprintf("%+v", volumeCtx))
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -395,13 +395,15 @@ func (d *Driver) CreateVolume(ctx context.Context, request *csi.CreateVolumeRequ
 
 func (d *Driver) DeleteVolume(ctx context.Context, request *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	traceID := uuid.New().String()
-	d.log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] ========== Start DeleteVolume ============", traceID))
+	log := d.log.Named("DeleteVolume").With("traceID", traceID, "volumeID", request.VolumeId)
+
+	log.Info("start")
 	if len(request.VolumeId) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
 	}
 
 	volumeCleanup := func() string {
-		localStorageClass, err := utils.GetLSCBeforeLLVDelete(ctx, d.cl, *d.log, request.VolumeId, traceID)
+		localStorageClass, err := utils.GetLSCBeforeLLVDelete(ctx, d.cl, log, request.VolumeId)
 		if err == nil && localStorageClass != nil && localStorageClass.Spec.LVM != nil {
 			return localStorageClass.Spec.LVM.VolumeCleanup
 		}
@@ -412,18 +414,17 @@ func (d *Driver) DeleteVolume(ctx context.Context, request *csi.DeleteVolumeRequ
 		return nil, errors.New("volumeCleanup is not supported in your edition")
 	}
 
-	err := utils.DeleteLVMLogicalVolume(ctx, d.cl, d.log, traceID, request.VolumeId, volumeCleanup)
+	err := utils.DeleteLVMLogicalVolume(ctx, d.cl, log, request.VolumeId, volumeCleanup)
 	if err != nil {
-		d.log.Error(err, "error DeleteLVMLogicalVolume")
+		log.Error("unable to delete the LVMLogicalVolume", logger.Err(err))
 		return nil, err
 	}
-	d.log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s][volumeID:%s] Volume deleted successfully", traceID, request.VolumeId))
-	d.log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] ========== END DeleteVolume ============", traceID))
+	log.Info("volume deleted successfully")
 	return &csi.DeleteVolumeResponse{}, nil
 }
 
 func (d *Driver) ControllerPublishVolume(_ context.Context, request *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	d.log.Info("method ControllerPublishVolume")
+	d.log.Named("ControllerPublishVolume").Info("called")
 	return &csi.ControllerPublishVolumeResponse{
 		PublishContext: map[string]string{
 			d.publishInfoVolumeName: request.VolumeId,
@@ -432,23 +433,23 @@ func (d *Driver) ControllerPublishVolume(_ context.Context, request *csi.Control
 }
 
 func (d *Driver) ControllerUnpublishVolume(_ context.Context, _ *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	d.log.Info("method ControllerUnpublishVolume")
+	d.log.Named("ControllerUnpublishVolume").Info("called")
 	// todo called Immediate
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
 func (d *Driver) ValidateVolumeCapabilities(_ context.Context, _ *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	d.log.Info("call method ValidateVolumeCapabilities")
+	d.log.Named("ValidateVolumeCapabilities").Info("called")
 	return nil, nil
 }
 
 func (d *Driver) ListVolumes(_ context.Context, _ *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	d.log.Info("call method ListVolumes")
+	d.log.Named("ListVolumes").Info("called")
 	return nil, nil
 }
 
 func (d *Driver) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
-	d.log.Info("method GetCapacity")
+	d.log.Named("GetCapacity").Info("called")
 
 	// todo MaxSize one PV
 	// todo call volumeBindingMode: WaitForFirstConsumer
@@ -461,7 +462,7 @@ func (d *Driver) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (*csi
 }
 
 func (d *Driver) ControllerGetCapabilities(_ context.Context, _ *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	d.log.Info("method ControllerGetCapabilities")
+	d.log.Named("ControllerGetCapabilities").Info("called")
 
 	var capabilities = []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
@@ -495,10 +496,9 @@ func (d *Driver) ControllerGetCapabilities(_ context.Context, _ *csi.ControllerG
 func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	traceID := uuid.New().String()
 
-	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s] method ControllerExpandVolume", traceID))
-	d.log.Trace(fmt.Sprintf("[ControllerExpandVolume][traceID:%s] ========== ControllerExpandVolume ============", traceID))
-	d.log.Trace(request.String())
-	d.log.Trace(fmt.Sprintf("[ControllerExpandVolume][traceID:%s] ========== ControllerExpandVolume ============", traceID))
+	log := d.log.Named("ControllerExpandVolume").With("traceID", traceID, "volumeID", request.GetVolumeId())
+
+	log.Trace("start", "request", request.String())
 
 	volumeID := request.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -507,29 +507,29 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.Contro
 
 	llv, err := utils.GetLVMLogicalVolume(ctx, d.cl, volumeID, "")
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] error getting LVMLogicalVolume", traceID, volumeID))
+		log.Error("unable to get the LVMLogicalVolume", logger.Err(err))
 		return nil, status.Errorf(codes.Internal, "error getting LVMLogicalVolume: %s", err.Error())
 	}
 
 	lvg, err := utils.GetLVMVolumeGroup(ctx, d.cl, llv.Spec.LVMVolumeGroupName)
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] error getting LVMVolumeGroup", traceID, volumeID))
+		log.Error("unable to get the LVMVolumeGroup", logger.Err(err), slog.String("lvgName", llv.Spec.LVMVolumeGroupName))
 		return nil, status.Errorf(codes.Internal, "error getting LVMVolumeGroup: %v", err)
 	}
 
 	requestCapacity := resource.NewQuantity(request.CapacityRange.GetRequiredBytes(), resource.BinarySI)
-	d.log.Trace(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] requestCapacity: %s", traceID, volumeID, requestCapacity.String()))
+	log.Trace("requested capacity", "requestCapacity", requestCapacity.String())
 
-	alignedRequestCapacity, err := d.alignToLVGExtentOrStatusErr(traceID, volumeID, *requestCapacity, lvg)
+	alignedRequestCapacity, err := alignToLVGExtentOrStatusErr(log, *requestCapacity, lvg)
 	if err != nil {
 		return nil, err
 	}
 
 	nodeExpansionRequired := request.GetVolumeCapability().GetBlock() == nil
-	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] NodeExpansionRequired: %t", traceID, volumeID, nodeExpansionRequired))
+	log.Info("resolved node expansion requirement", "nodeExpansionRequired", nodeExpansionRequired)
 
 	if llv.Status.ActualSize.Value() >= alignedRequestCapacity.Value() {
-		d.log.Warning(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] actual size %s is already >= aligned requested size %s, no need to resize LVMLogicalVolume %s, return NodeExpansionRequired: %t and CapacityBytes: %d", traceID, volumeID, llv.Status.ActualSize.String(), alignedRequestCapacity.String(), volumeID, nodeExpansionRequired, llv.Status.ActualSize.Value()))
+		log.Warn("the actual size already covers the aligned request, skipping the resize", "actualSize", llv.Status.ActualSize.String(), "alignedRequestSize", alignedRequestCapacity.String(), "nodeExpansionRequired", nodeExpansionRequired, "capacityBytes", llv.Status.ActualSize.Value())
 		return &csi.ControllerExpandVolumeResponse{
 			CapacityBytes:         llv.Status.ActualSize.Value(),
 			NodeExpansionRequired: nodeExpansionRequired,
@@ -540,32 +540,31 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.Contro
 		lvgFreeSpace := utils.GetLVMVolumeGroupFreeSpace(*lvg)
 
 		if lvgFreeSpace.Value() < (alignedRequestCapacity.Value() - llv.Status.ActualSize.Value()) {
-			d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] requested size: %s is greater than the capacity of the LVMVolumeGroup: %s", traceID, volumeID, alignedRequestCapacity.String(), lvgFreeSpace.String()))
+			log.Error("the requested size exceeds the free space of the LVMVolumeGroup", slog.String("alignedRequestSize", alignedRequestCapacity.String()), slog.String("lvgFreeSpace", lvgFreeSpace.String()))
 			return nil, status.Errorf(codes.Internal, "requested size: %s is greater than the capacity of the LVMVolumeGroup: %s", alignedRequestCapacity.String(), lvgFreeSpace.String())
 		}
 	}
 
-	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] start resize LVMLogicalVolume", traceID, volumeID))
-	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] requested size: %s, actual size: %s", traceID, volumeID, requestCapacity.String(), llv.Status.ActualSize.String()))
+	log.Info("resizing the LVMLogicalVolume", "requestedSize", requestCapacity.String(), "actualSize", llv.Status.ActualSize.String())
 	err = utils.ExpandLVMLogicalVolume(ctx, d.cl, llv, requestCapacity.String())
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] error updating LVMLogicalVolume", traceID, volumeID))
+		log.Error("unable to update the LVMLogicalVolume", logger.Err(err))
 		return nil, status.Errorf(codes.Internal, "error updating LVMLogicalVolume: %v", err)
 	}
 
-	updatedLLV, attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, d.log, traceID, llv.Name, llv.Namespace, *requestCapacity, utils.SafeExtentSize(lvg.Status.ExtentSize))
+	updatedLLV, attemptCounter, err := utils.WaitForStatusUpdate(ctx, d.cl, log, llv.Name, llv.Namespace, *requestCapacity, utils.SafeExtentSize(lvg.Status.ExtentSize))
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] error WaitForStatusUpdate", traceID, volumeID))
+		log.Error("the resized LVMLogicalVolume did not become ready", logger.Err(err))
 		return nil, err
 	}
-	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] finish resize LVMLogicalVolume, attempt counter = %d ", traceID, volumeID, attemptCounter))
+	log.Info("the LVMLogicalVolume was resized", "attempts", attemptCounter)
 
 	capacityBytes, fromStatus := resolveCapacityBytes(updatedLLV, alignedRequestCapacity)
 	if !fromStatus {
-		d.log.Warning(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] LVMLogicalVolume %s has no status after a successful wait, reporting the aligned requested size %s", traceID, volumeID, llv.Name, alignedRequestCapacity.String()))
+		log.Warn("the LVMLogicalVolume has no status after a successful wait, reporting the aligned requested size", "llvName", llv.Name, "alignedSize", alignedRequestCapacity.String())
 	}
 
-	d.log.Info(fmt.Sprintf("[ControllerExpandVolume][traceID:%s][volumeID:%s] Volume expanded successfully", traceID, volumeID))
+	log.Info("volume expanded successfully")
 
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         capacityBytes,
@@ -574,11 +573,11 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, request *csi.Contro
 }
 
 func (d *Driver) ControllerGetVolume(_ context.Context, _ *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
-	d.log.Info(" call method ControllerGetVolume")
+	d.log.Named("ControllerGetVolume").Info("called")
 	return &csi.ControllerGetVolumeResponse{}, nil
 }
 
 func (d *Driver) ControllerModifyVolume(_ context.Context, _ *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
-	d.log.Info(" call method ControllerModifyVolume")
+	d.log.Named("ControllerModifyVolume").Info("called")
 	return &csi.ControllerModifyVolumeResponse{}, nil
 }

--- a/images/sds-local-volume-csi/driver/controller_snapshots_ee.go
+++ b/images/sds-local-volume-csi/driver/controller_snapshots_ee.go
@@ -155,7 +155,7 @@ func (d *Driver) DeleteSnapshot(ctx context.Context, request *csi.DeleteSnapshot
 	}
 
 	d.log.Info(fmt.Sprintf("[Snapshot][traceID:%s][SnapshotId:%s] Snapshot deleted successfully", traceID, request.SnapshotId))
-	d.log.Info("[Snapshot][traceID:%s] ========== END Snapshot ============", traceID)
+	d.log.Info(fmt.Sprintf("[Snapshot][traceID:%s] ========== END Snapshot ============", traceID))
 	return &csi.DeleteSnapshotResponse{}, nil
 }
 

--- a/images/sds-local-volume-csi/driver/controller_snapshots_ee.go
+++ b/images/sds-local-volume-csi/driver/controller_snapshots_ee.go
@@ -9,7 +9,7 @@ package driver
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -20,6 +20,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/internal"
+	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/pkg/logger"
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/pkg/utils"
 	"github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
@@ -27,12 +28,12 @@ import (
 func (d *Driver) CreateSnapshot(ctx context.Context, request *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	traceID := uuid.New().String()
 
-	d.log.Trace(fmt.Sprintf("[CreateSnapshot][traceID:%s] ========== CreateSnapshot ============", traceID))
-	d.log.Trace(request.String())
+	log := d.log.Named("CreateSnapshot").With("traceID", traceID, "sourceVolumeID", request.SourceVolumeId)
+	log.Trace("start", "request", request.String())
 
 	llv, err := utils.GetLVMLogicalVolume(ctx, d.cl, request.SourceVolumeId, "")
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] error getting LVMLogicalVolume", traceID, request.SourceVolumeId))
+		log.Error("unable to get the source LVMLogicalVolume", logger.Err(err))
 		return nil, status.Errorf(codes.Internal, "error getting LVMLogicalVolume %s: %s", request.SourceVolumeId, err.Error())
 	}
 
@@ -46,15 +47,7 @@ func (d *Driver) CreateSnapshot(ctx context.Context, request *csi.CreateSnapshot
 
 	lvg, err := utils.GetLVMVolumeGroup(ctx, d.cl, llv.Spec.LVMVolumeGroupName)
 	if err != nil {
-		d.log.Error(
-			err,
-			fmt.Sprintf(
-				"[CreateSnapshot][traceID:%s][volumeID:%s] error getting LVMVolumeGroup %s",
-				traceID,
-				request.SourceVolumeId,
-				llv.Spec.LVMVolumeGroupName,
-			),
-		)
+		log.Error("unable to get the LVMVolumeGroup", logger.Err(err), slog.String("lvgName", llv.Spec.LVMVolumeGroupName))
 		return nil, status.Errorf(codes.Internal, "error getting LVMVolumeGroup %s: %s", llv.Spec.LVMVolumeGroupName, err.Error())
 	}
 
@@ -89,7 +82,6 @@ func (d *Driver) CreateSnapshot(ctx context.Context, request *csi.CreateSnapshot
 		ctx,
 		d.cl,
 		d.log,
-		traceID,
 		name,
 		v1alpha1.LVMLogicalVolumeSnapshotSpec{
 			ActualSnapshotNameOnTheNode: actualNameOnTheNode,
@@ -98,26 +90,26 @@ func (d *Driver) CreateSnapshot(ctx context.Context, request *csi.CreateSnapshot
 	)
 	if err != nil {
 		if kerrors.IsAlreadyExists(err) {
-			d.log.Info(fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] LVMLogicalVolumeSnapshot %s already exists. Skip creating", traceID, name, name))
+			log.Info("the LVMLogicalVolumeSnapshot already exists, skipping creation", "llvsName", name)
 		} else {
-			d.log.Error(err, fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] error CreateLVMLogicalVolume", traceID, name))
+			log.Error("unable to create the LVMLogicalVolumeSnapshot", logger.Err(err), slog.String("llvsName", name))
 			return nil, err
 		}
 	}
 
-	attemptCounter, err := utils.WaitForLLVSStatusUpdate(ctx, d.cl, d.log, traceID, name)
+	attemptCounter, err := utils.WaitForLLVSStatusUpdate(ctx, d.cl, log, name)
 	if err != nil {
-		d.log.Error(err, fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] error WaitForStatusUpdate. DeleteLVMLogicalVolumeSnapshot %s", traceID, name, request.Name))
+		log.Error("the LVMLogicalVolumeSnapshot did not become ready, deleting it", logger.Err(err), slog.String("llvsName", request.Name))
 
-		deleteErr := utils.DeleteLVMLogicalVolumeSnapshot(ctx, d.cl, d.log, traceID, request.Name)
+		deleteErr := utils.DeleteLVMLogicalVolumeSnapshot(ctx, d.cl, log, request.Name)
 		if deleteErr != nil {
-			d.log.Error(deleteErr, fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] error DeleteLVMLogicalVolumeSnapshot", traceID, name))
+			log.Error("unable to delete the LVMLogicalVolumeSnapshot after a failed wait", logger.Err(deleteErr), slog.String("llvsName", request.Name))
 		}
 
-		d.log.Error(err, fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] error creating LVMLogicalVolumeSnapshot", traceID, name))
+		log.Error("unable to create the snapshot", logger.Err(err))
 		return nil, err
 	}
-	d.log.Trace(fmt.Sprintf("[CreateSnapshot][traceID:%s][volumeID:%s] finish wait CreateLVMLogicalVolume, attempt counter = %d", traceID, name, attemptCounter))
+	log.Trace("the LVMLogicalVolumeSnapshot became ready", "attempts", attemptCounter)
 
 	// Reported from the status, not from Spec.Size: the node rounds the LV up to the
 	// extent boundary, and volumes provisioned before the CSI side started aligning
@@ -147,19 +139,19 @@ func (d *Driver) DeleteSnapshot(ctx context.Context, request *csi.DeleteSnapshot
 	}
 
 	traceID := uuid.New().String()
-	d.log.Trace(fmt.Sprintf("[DeleteSnapshot][traceID:%s] ========== DeleteSnapshot ============", traceID))
-	d.log.Trace(request.String())
+	log := d.log.Named("DeleteSnapshot").With("traceID", traceID, "snapshotID", request.SnapshotId)
+	log.Trace("start", "request", request.String())
 
-	if err := utils.DeleteLVMLogicalVolumeSnapshot(ctx, d.cl, d.log, traceID, request.SnapshotId); err != nil {
-		d.log.Error(err, "error DeleteLVMLogicalVolume")
+	if err := utils.DeleteLVMLogicalVolumeSnapshot(ctx, d.cl, log, request.SnapshotId); err != nil {
+		log.Error("unable to delete the LVMLogicalVolumeSnapshot", logger.Err(err))
 	}
 
-	d.log.Info(fmt.Sprintf("[Snapshot][traceID:%s][SnapshotId:%s] Snapshot deleted successfully", traceID, request.SnapshotId))
-	d.log.Info(fmt.Sprintf("[Snapshot][traceID:%s] ========== END Snapshot ============", traceID))
+	log.Info("snapshot deleted successfully")
+
 	return &csi.DeleteSnapshotResponse{}, nil
 }
 
 func (d *Driver) ListSnapshots(_ context.Context, _ *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
-	d.log.Info("call method ListSnapshots")
+	d.log.Named("ListSnapshots").Info("called")
 	return nil, nil
 }

--- a/images/sds-local-volume-csi/driver/driver.go
+++ b/images/sds-local-volume-csi/driver/driver.go
@@ -109,15 +109,14 @@ func (d *Driver) Run(ctx context.Context) error {
 		return fmt.Errorf("unable to parse address: %q", err)
 	}
 
-	fmt.Print("d.csiAddress", d.csiAddress)
-	fmt.Print("u", u)
-
 	grpcAddr := path.Join(u.Host, filepath.FromSlash(u.Path))
 	if u.Host == "" {
 		grpcAddr = filepath.FromSlash(u.Path)
 	}
 
-	fmt.Print("grpcAddr", grpcAddr)
+	// These three values used to be dumped to stdout with fmt.Print, bypassing the
+	// logger and the configured level entirely.
+	d.log.Trace(fmt.Sprintf("[Run] csiAddress: %s, parsed URL: %s, grpcAddr: %s", d.csiAddress, u, grpcAddr))
 
 	// CSI plugins talk only over UNIX sockets currently
 	if u.Scheme != "unix" {

--- a/images/sds-local-volume-csi/driver/driver.go
+++ b/images/sds-local-volume-csi/driver/driver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -65,7 +66,7 @@ type Driver struct {
 
 	srv     *grpc.Server
 	httpSrv http.Server
-	log     *logger.Logger
+	log     logger.Logger
 	metrics monitoring.Recorder
 
 	readyMu      sync.Mutex // protects ready
@@ -82,7 +83,7 @@ type Driver struct {
 // NewDriver returns a CSI plugin that contains the necessary gRPC
 // interfaces to interact with Kubernetes over unix domain sockets for
 // managing  disks
-func NewDriver(csiAddress, driverName, address string, nodeName *string, log *logger.Logger, metrics monitoring.Recorder, cl client.Client) (*Driver, error) {
+func NewDriver(csiAddress, driverName, address string, nodeName *string, log logger.Logger, metrics monitoring.Recorder, cl client.Client) (*Driver, error) {
 	if driverName == "" {
 		driverName = DefaultDriverName
 	}
@@ -104,6 +105,8 @@ func NewDriver(csiAddress, driverName, address string, nodeName *string, log *lo
 }
 
 func (d *Driver) Run(ctx context.Context) error {
+	log := d.log.Named("Run")
+
 	u, err := url.Parse(d.csiAddress)
 	if err != nil {
 		return fmt.Errorf("unable to parse address: %q", err)
@@ -116,7 +119,7 @@ func (d *Driver) Run(ctx context.Context) error {
 
 	// These three values used to be dumped to stdout with fmt.Print, bypassing the
 	// logger and the configured level entirely.
-	d.log.Trace(fmt.Sprintf("[Run] csiAddress: %s, parsed URL: %s, grpcAddr: %s", d.csiAddress, u, grpcAddr))
+	log.Trace("resolved the listen addresses", "csiAddress", d.csiAddress, "parsedURL", u.String(), "grpcAddr", grpcAddr)
 
 	// CSI plugins talk only over UNIX sockets currently
 	if u.Scheme != "unix" {
@@ -125,7 +128,7 @@ func (d *Driver) Run(ctx context.Context) error {
 	// remove the socket if it's already there. This can happen if we
 	// deploy a new version and the socket was created from the old running
 	// plugin.
-	d.log.Info(fmt.Sprintf("socket %s removing socket", grpcAddr))
+	log.Info("removing a stale socket", "grpcAddr", grpcAddr)
 	if err := os.Remove(grpcAddr); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove unix domain socket file %s, error: %s", grpcAddr, err)
 	}
@@ -143,7 +146,7 @@ func (d *Driver) Run(ctx context.Context) error {
 		resp, err := handler(ctx, req)
 		d.metrics.ObserveOperation(info.FullMethod, start, err)
 		if err != nil {
-			d.log.Error(err, fmt.Sprintf("method %s method failed ", info.FullMethod))
+			log.Error("the CSI method failed", logger.Err(err), slog.String("method", info.FullMethod))
 		}
 		return resp, err
 	}
@@ -168,7 +171,7 @@ func (d *Driver) Run(ctx context.Context) error {
 	}
 
 	d.ready = true
-	d.log.Info(fmt.Sprintf("grpc_addr %s http_addr %s starting server", grpcAddr, d.address))
+	log.Info("starting the servers", "grpcAddr", grpcAddr, "httpAddr", d.address)
 
 	var eg errgroup.Group
 	eg.Go(func() error {
@@ -178,7 +181,7 @@ func (d *Driver) Run(ctx context.Context) error {
 	eg.Go(func() error {
 		go func() {
 			<-ctx.Done()
-			d.log.Info("server stopped")
+			log.Info("server stopped")
 			d.readyMu.Lock()
 			d.ready = false
 			d.readyMu.Unlock()

--- a/images/sds-local-volume-csi/driver/identity.go
+++ b/images/sds-local-volume-csi/driver/identity.go
@@ -31,13 +31,12 @@ func (d *Driver) GetPluginInfo(_ context.Context, _ *csi.GetPluginInfoRequest) (
 		VendorVersion: version,
 	}
 
-	d.log.Info(fmt.Sprintf("response : %+v ", resp))
+	d.log.Named("GetPluginInfo").Info("called", "response", fmt.Sprintf("%+v", resp))
 	return resp, nil
 }
 
 // GetPluginCapabilities returns available capabilities of the plugin
 func (d *Driver) GetPluginCapabilities(_ context.Context, _ *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	d.log.Info("method GetPluginCapabilities")
 	resp := &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{
@@ -71,13 +70,13 @@ func (d *Driver) GetPluginCapabilities(_ context.Context, _ *csi.GetPluginCapabi
 		},
 	}
 
-	d.log.Info(fmt.Sprintf("response method get_plugin_capabilities get plugin capabitilies called : %+v", resp))
+	d.log.Named("GetPluginCapabilities").Info("called", "response", fmt.Sprintf("%+v", resp))
 	return resp, nil
 }
 
 // Probe returns the health and readiness of the plugin
 func (d *Driver) Probe(_ context.Context, _ *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	d.log.Info("method Probe")
+	d.log.Named("Probe").Info("called")
 	d.readyMu.Lock()
 	defer d.readyMu.Unlock()
 

--- a/images/sds-local-volume-csi/driver/node.go
+++ b/images/sds-local-volume-csi/driver/node.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strconv"
@@ -32,6 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/internal"
+	"github.com/deckhouse/sds-local-volume/images/sds-local-volume-csi/pkg/logger"
 )
 
 const (
@@ -60,6 +62,7 @@ var (
 
 func (d *Driver) NodeStageVolume(_ context.Context, request *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	volumeID := request.GetVolumeId()
+	log := d.log.Named("NodeStageVolume").With("volumeID", volumeID)
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "[NodeStageVolume] Volume id cannot be empty")
 	}
@@ -81,7 +84,7 @@ func (d *Driver) NodeStageVolume(_ context.Context, request *csi.NodeStageVolume
 	}
 
 	if volCap.GetBlock() != nil {
-		d.log.Info("[NodeStageVolume] Block volume detected. Skipping staging.")
+		log.Info("block volume detected, skipping staging")
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
@@ -97,7 +100,7 @@ func (d *Driver) NodeStageVolume(_ context.Context, request *csi.NodeStageVolume
 
 	_, ok = ValidFSTypes[strings.ToLower(fsType)]
 	if !ok {
-		d.log.Error(fmt.Errorf("[NodeStageVolume] Invalid fsType: %s. Supported values: %v", fsType, ValidFSTypes), "Invalid fsType")
+		log.Error("invalid filesystem type", slog.String("fsType", fsType), slog.String("supported", fmt.Sprintf("%v", ValidFSTypes)))
 		return nil, status.Errorf(codes.InvalidArgument, "invalid fsType")
 	}
 
@@ -109,24 +112,24 @@ func (d *Driver) NodeStageVolume(_ context.Context, request *csi.NodeStageVolume
 		return nil, err
 	}
 	if fsType == internal.FSTypeXfs && needLegacySupport {
-		d.log.Info("[NodeStageVolume] legacy xfs support is on")
+		log.Info("legacy xfs support is on")
 		formatOptions = append(formatOptions, "-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0")
 	}
 
 	mountOptions := collectMountOptions(fsType, mountVolume.GetMountFlags(), []string{})
 
-	d.log.Debug(fmt.Sprintf("[NodeStageVolume] Volume %s operation started", volumeID))
+	log.Debug("volume operation started")
 	ok = d.inFlight.Insert(volumeID)
 	if !ok {
 		return nil, status.Errorf(codes.Aborted, VolumeOperationAlreadyExists, volumeID)
 	}
 	defer func() {
-		d.log.Debug(fmt.Sprintf("[NodeStageVolume] Volume %s operation completed", volumeID))
+		log.Debug("volume operation completed")
 		d.inFlight.Delete(volumeID)
 	}()
 
 	devPath := fmt.Sprintf("/dev/%s/%s", vgName, request.VolumeId)
-	d.log.Debug(fmt.Sprintf("[NodeStageVolume] Checking if device exists: %s", devPath))
+	log.Debug("checking whether the device exists", "devicePath", devPath)
 	exists, err := d.storeManager.PathExists(devPath)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "[NodeStageVolume] Error checking if device exists: %v", err)
@@ -138,40 +141,41 @@ func (d *Driver) NodeStageVolume(_ context.Context, request *csi.NodeStageVolume
 	lvmType := context[internal.LvmTypeKey]
 	lvmThinPoolName := context[internal.ThinPoolNameKey]
 
-	d.log.Trace(fmt.Sprintf("formatOptions = %s", formatOptions))
-	d.log.Trace(fmt.Sprintf("mountOptions = %s", mountOptions))
-	d.log.Trace(fmt.Sprintf("lvmType = %s", lvmType))
-	d.log.Trace(fmt.Sprintf("lvmThinPoolName = %s", lvmThinPoolName))
-	d.log.Trace(fmt.Sprintf("fsType = %s", fsType))
+	log.Trace("resolved format options", "formatOptions", formatOptions)
+	log.Trace("resolved mount options", "mountOptions", mountOptions)
+	log.Trace("resolved LVM type", "lvmType", lvmType)
+	log.Trace("resolved thin pool", "thinPoolName", lvmThinPoolName)
+	log.Trace("resolved filesystem type", "fsType", fsType)
 
 	err = d.storeManager.NodeStageVolumeFS(devPath, target, fsType, mountOptions, formatOptions, lvmType, lvmThinPoolName)
 	if err != nil {
-		d.log.Error(err, "[NodeStageVolume] Error mounting volume")
+		log.Error("unable to mount the volume", logger.Err(err), slog.String("devicePath", devPath), slog.String("target", target))
 		return nil, status.Errorf(codes.Internal, "[NodeStageVolume] Error format device %q and mounting volume at %q: %v", devPath, target, err)
 	}
 
 	needResize, err := d.storeManager.NeedResize(devPath, target)
 	if err != nil {
-		d.log.Error(err, "[NodeStageVolume] Error checking if volume needs resize")
+		log.Error("unable to check whether the volume needs resizing", logger.Err(err), slog.String("devicePath", devPath), slog.String("target", target))
 		return nil, status.Errorf(codes.Internal, "[NodeStageVolume] Error checking if the volume %q (%q) mounted at %q needs resizing: %v", volumeID, devPath, target, err)
 	}
 
 	if needResize {
-		d.log.Info(fmt.Sprintf("[NodeStageVolume] Resizing volume %q (%q) mounted at %q", volumeID, devPath, target))
+		log.Info("resizing the volume", "devicePath", devPath, "target", target)
 		err = d.storeManager.ResizeFS(target)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "[NodeStageVolume] Error resizing volume %q (%q) mounted at %q: %v", volumeID, devPath, target, err)
 		}
 	}
 
-	d.log.Info(fmt.Sprintf("[NodeStageVolume] Volume %q (%q) successfully staged at %s. FsType: %s", volumeID, devPath, target, fsType))
+	log.Info("volume staged successfully", "devicePath", devPath, "target", target, "fsType", fsType)
 
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
 func (d *Driver) NodeUnstageVolume(_ context.Context, request *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
-	d.log.Debug(fmt.Sprintf("[NodeUnstageVolume] method called with request: %v", request))
 	volumeID := request.GetVolumeId()
+	log := d.log.Named("NodeUnstageVolume").With("volumeID", volumeID)
+	log.Debug("called", "request", fmt.Sprintf("%v", request))
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "[NodeUnstageVolume] Volume id cannot be empty")
 	}
@@ -181,13 +185,13 @@ func (d *Driver) NodeUnstageVolume(_ context.Context, request *csi.NodeUnstageVo
 		return nil, status.Error(codes.InvalidArgument, "[NodeUnstageVolume] Staging target path cannot be empty")
 	}
 
-	d.log.Debug(fmt.Sprintf("[NodeUnstageVolume] Volume %s operation started", volumeID))
+	log.Debug("volume operation started")
 	ok := d.inFlight.Insert(volumeID)
 	if !ok {
 		return nil, status.Errorf(codes.Aborted, VolumeOperationAlreadyExists, volumeID)
 	}
 	defer func() {
-		d.log.Debug(fmt.Sprintf("[NodeUnstageVolume] Volume %s operation completed", volumeID))
+		log.Debug("volume operation completed")
 		d.inFlight.Delete(volumeID)
 	}()
 	err := d.storeManager.Unstage(target)
@@ -199,10 +203,9 @@ func (d *Driver) NodeUnstageVolume(_ context.Context, request *csi.NodeUnstageVo
 }
 
 func (d *Driver) NodePublishVolume(_ context.Context, request *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	d.log.Info("Start method NodePublishVolume")
-	d.log.Trace("------------- NodePublishVolume --------------")
-	d.log.Trace(request.String())
-	d.log.Trace("------------- NodePublishVolume --------------")
+	log := d.log.Named("NodePublishVolume").With("volumeID", request.GetVolumeId())
+
+	log.Trace("start", "request", request.String())
 
 	volumeID := request.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -235,7 +238,7 @@ func (d *Driver) NodePublishVolume(_ context.Context, request *csi.NodePublishVo
 	}
 
 	devPath := fmt.Sprintf("/dev/%s/%s", vgName, request.VolumeId)
-	d.log.Debug(fmt.Sprintf("[NodePublishVolume] Checking if device exists: %s", devPath))
+	log.Debug("checking whether the device exists", "devicePath", devPath)
 	exists, err := d.storeManager.PathExists(devPath)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "[NodePublishVolume] Error checking if device exists: %v", err)
@@ -244,20 +247,20 @@ func (d *Driver) NodePublishVolume(_ context.Context, request *csi.NodePublishVo
 		return nil, status.Errorf(codes.NotFound, "[NodePublishVolume] Device %q not found", devPath)
 	}
 
-	d.log.Debug(fmt.Sprintf("[NodePublishVolume] Volume %s operation started", volumeID))
+	log.Debug("volume operation started")
 
 	ok = d.inFlight.Insert(volumeID)
 	if !ok {
 		return nil, status.Errorf(codes.Aborted, VolumeOperationAlreadyExists, volumeID)
 	}
 	defer func() {
-		d.log.Debug(fmt.Sprintf("[NodePublishVolume] Volume %s operation completed", volumeID))
+		log.Debug("volume operation completed")
 		d.inFlight.Delete(volumeID)
 	}()
 
 	switch volCap.GetAccessType().(type) {
 	case *csi.VolumeCapability_Block:
-		d.log.Trace("[NodePublishVolume] Block volume detected.")
+		log.Trace("block volume detected")
 
 		err := d.storeManager.NodePublishVolumeBlock(devPath, target, mountOptions)
 		if err != nil {
@@ -265,7 +268,7 @@ func (d *Driver) NodePublishVolume(_ context.Context, request *csi.NodePublishVo
 		}
 
 	case *csi.VolumeCapability_Mount:
-		d.log.Trace("[NodePublishVolume] FS type volume detected.")
+		log.Trace("filesystem volume detected")
 		mountVolume := volCap.GetMount()
 		if mountVolume == nil {
 			return nil, status.Error(codes.InvalidArgument, "[NodePublishVolume] Volume capability mount cannot be empty")
@@ -277,7 +280,7 @@ func (d *Driver) NodePublishVolume(_ context.Context, request *csi.NodePublishVo
 
 		_, ok = ValidFSTypes[strings.ToLower(fsType)]
 		if !ok {
-			d.log.Error(fmt.Errorf("[NodeStageVolume] Invalid fsType: %s. Supported values: %v", fsType, ValidFSTypes), "Invalid fsType")
+			log.Error("invalid filesystem type", slog.String("fsType", fsType), slog.String("supported", fmt.Sprintf("%v", ValidFSTypes)))
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid fsType")
 		}
 
@@ -293,10 +296,10 @@ func (d *Driver) NodePublishVolume(_ context.Context, request *csi.NodePublishVo
 }
 
 func (d *Driver) NodeUnpublishVolume(_ context.Context, request *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
-	d.log.Debug(fmt.Sprintf("[NodeUnpublishVolume] method called with request: %v", request))
-	d.log.Trace("------------- NodeUnpublishVolume --------------")
-	d.log.Trace(request.String())
-	d.log.Trace("------------- NodeUnpublishVolume --------------")
+	log := d.log.Named("NodeUnpublishVolume").With("volumeID", request.GetVolumeId())
+	log.Debug("called", "request", fmt.Sprintf("%v", request))
+
+	log.Trace("start", "request", request.String())
 
 	volumeID := request.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -308,13 +311,13 @@ func (d *Driver) NodeUnpublishVolume(_ context.Context, request *csi.NodeUnpubli
 		return nil, status.Error(codes.InvalidArgument, "[NodeUnpublishVolume] Staging target path cannot be empty")
 	}
 
-	d.log.Debug(fmt.Sprintf("[NodeUnpublishVolume] Volume %s operation started", volumeID))
+	log.Debug("volume operation started")
 	ok := d.inFlight.Insert(volumeID)
 	if !ok {
 		return nil, status.Errorf(codes.Aborted, VolumeOperationAlreadyExists, volumeID)
 	}
 	defer func() {
-		d.log.Debug(fmt.Sprintf("[NodeUnpublishVolume] Volume %s operation completed", volumeID))
+		log.Debug("volume operation completed")
 		d.inFlight.Delete(volumeID)
 	}()
 
@@ -357,7 +360,7 @@ func (d *Driver) getBlockSizeBytes(devicePath string) (uint64, error) {
 }
 
 func (d *Driver) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	d.log.Info("method NodeGetVolumeStats")
+	d.log.Named("NodeGetVolumeStats").Info("called")
 
 	isBlock, err := d.IsBlockDevice(req.VolumePath)
 
@@ -413,11 +416,9 @@ func (d *Driver) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolumeSta
 }
 
 func (d *Driver) NodeExpandVolume(_ context.Context, request *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	d.log.Info("Call method NodeExpandVolume")
+	log := d.log.Named("NodeExpandVolume").With("volumeID", request.GetVolumeId())
 
-	d.log.Trace("========== NodeExpandVolume ============")
-	d.log.Trace(request.String())
-	d.log.Trace("========== NodeExpandVolume ============")
+	log.Trace("start", "request", request.String())
 
 	volumeID := request.GetVolumeId()
 	volumePath := request.GetVolumePath()
@@ -430,7 +431,7 @@ func (d *Driver) NodeExpandVolume(_ context.Context, request *csi.NodeExpandVolu
 
 	err := d.storeManager.ResizeFS(volumePath)
 	if err != nil {
-		d.log.Error(err, "d.mounter.ResizeFS:")
+		log.Error("unable to resize the filesystem", logger.Err(err))
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -438,7 +439,7 @@ func (d *Driver) NodeExpandVolume(_ context.Context, request *csi.NodeExpandVolu
 }
 
 func (d *Driver) NodeGetCapabilities(_ context.Context, request *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	d.log.Debug(fmt.Sprintf("[NodeGetCapabilities] method called with request: %v", request))
+	d.log.Named("NodeGetCapabilities").Debug("called", "request", fmt.Sprintf("%v", request))
 
 	caps := make([]*csi.NodeServiceCapability, len(nodeCaps))
 	for i, capability := range nodeCaps {
@@ -457,8 +458,7 @@ func (d *Driver) NodeGetCapabilities(_ context.Context, request *csi.NodeGetCapa
 }
 
 func (d *Driver) NodeGetInfo(_ context.Context, _ *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	d.log.Info("method NodeGetInfo")
-	d.log.Info(fmt.Sprintf("hostID = %s", d.hostID))
+	d.log.Named("NodeGetInfo").Info("called", "hostID", d.hostID)
 
 	return &csi.NodeGetInfoResponse{
 		NodeId: d.hostID,

--- a/images/sds-local-volume-csi/go.mod
+++ b/images/sds-local-volume-csi/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/container-storage-interface/spec v1.10.0
+	github.com/deckhouse/deckhouse/pkg/log v0.2.1
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
 	github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787
 	github.com/deckhouse/sds-local-volume/lib/go/common v0.0.0-20250215220933-9c8f9f5ab53d
@@ -31,7 +32,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/deckhouse/deckhouse/pkg/log v0.1.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect

--- a/images/sds-local-volume-csi/go.sum
+++ b/images/sds-local-volume-csi/go.sum
@@ -10,8 +10,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/deckhouse/pkg/log v0.1.0 h1:2aPfyiHHSIJlX4x7ysyPOaIb7CLmyY+hUf9uDb8TYd8=
-github.com/deckhouse/deckhouse/pkg/log v0.1.0/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
+github.com/deckhouse/deckhouse/pkg/log v0.2.1 h1:7SSD+QJPnziAO3l8ycgRwN5wlQeC312Tf7f2Wa/hWDg=
+github.com/deckhouse/deckhouse/pkg/log v0.2.1/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 h1:xZvbKuexrSQGEw6CB4n3UC7XbOb9QNLbm8UhcGZ2R1I=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0/go.mod h1:Rz++SzCLkFW03WGgftnn91TimGU2shiKb5S/YuxcBuE=
 github.com/deckhouse/sds-node-configurator/api v0.0.0-20260318114210-2fdda7b75905 h1:OKwOW3JFlbMxG8lLM9rfLxl+2M8lFpThQRFAJy4lBMQ=

--- a/images/sds-local-volume-csi/pkg/logger/logger.go
+++ b/images/sds-local-volume-csi/pkg/logger/logger.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,16 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package logger wraps github.com/deckhouse/deckhouse/pkg/log in the small API
+// this module uses.
+//
+// The method set (Error/Warning/Info/Debug/Trace) is kept from the previous
+// klog-based implementation so that existing call sites are unaffected, and so
+// is the Verbosity type: LOG_LEVEL is delivered as a number 0..4 both by
+// lib-helm's helm_lib_module_controller_log_level and by the module's own CSI
+// templates, and that contract must not change.
 package logger
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/klog/v2/textlogger"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
+// Verbosity is the numeric LOG_LEVEL value taken from the environment.
 const (
 	ErrorLevel   Verbosity = "0"
 	WarningLevel Verbosity = "1"
@@ -32,52 +47,182 @@ const (
 	TraceLevel   Verbosity = "4"
 )
 
-const (
-	warnLvl = iota + 1
-	infoLvl
-	debugLvl
-	traceLvl
-)
-
 type (
 	Verbosity string
 )
 
-type Logger struct {
-	log logr.Logger
+// Level maps a numeric verbosity onto a log level.
+//
+// The mapping reproduces the thresholds of the previous klog-based logger, where
+// Warning was V(1), Info V(2), Debug V(3) and Trace V(4): a given LOG_LEVEL
+// keeps emitting exactly the same set of messages as before.
+func (v Verbosity) Level() (log.Level, error) {
+	n, err := strconv.Atoi(string(v))
+	if err != nil {
+		return log.LevelInfo, fmt.Errorf("parse verbosity %q: %w", string(v), err)
+	}
+
+	switch n {
+	case 0:
+		return log.LevelError, nil
+	case 1:
+		return log.LevelWarn, nil
+	case 2:
+		return log.LevelInfo, nil
+	case 3:
+		return log.LevelDebug, nil
+	default:
+		// Anything above TRACE stays at TRACE rather than being rejected; the
+		// previous implementation also accepted higher numbers.
+		if n < 0 {
+			return log.LevelInfo, fmt.Errorf("verbosity %d is negative", n)
+		}
+		return log.LevelTrace, nil
+	}
 }
 
+type Logger struct {
+	log *log.Logger
+}
+
+// nop backs the zero Logger. The previous logr-based implementation held a
+// logr.Logger by value, whose zero value discards silently, and callers rely on
+// that: a zero Logger must stay a no-op rather than panic.
+var nop = log.NewNop()
+
+// unwrap returns the underlying logger, substituting the discard logger for a
+// zero Logger.
+func (l Logger) unwrap() *log.Logger {
+	if l.log == nil {
+		return nop
+	}
+	return l.log
+}
+
+// NewLogger returns a logger emitting at the given verbosity.
 func NewLogger(level Verbosity) (*Logger, error) {
-	v, err := strconv.Atoi(string(level))
+	lvl, err := level.Level()
 	if err != nil {
 		return nil, err
 	}
 
-	log := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(v))).WithCallDepth(1)
-
-	return &Logger{log: log}, nil
+	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()))}, nil
 }
 
+// NewLoggerToWriter returns a logger writing to w, for tests that want the
+// output attached to their own reporter.
+func NewLoggerToWriter(w io.Writer, level Verbosity) (*Logger, error) {
+	lvl, err := level.Level()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()), log.WithOutput(w))}, nil
+}
+
+// NewNop returns a logger that discards everything, for tests that do not care
+// about log output.
+func NewNop() *Logger {
+	return &Logger{log: log.NewNop()}
+}
+
+// NewLoggerFromSlog adapts an existing pkg/log logger, so that a caller which
+// already built one does not have to reconfigure it.
+func NewLoggerFromSlog(l *log.Logger) Logger {
+	return Logger{log: l}
+}
+
+// Named appends name to the logger's dotted trace path, e.g. a logger named
+// "local-storage-class-controller" then named "reconcile" reports
+// "local-storage-class-controller.reconcile". Use it instead of hand-writing a
+// "[Component]" prefix into the message.
+func (l Logger) Named(name string) Logger {
+	return Logger{log: l.unwrap().Named(name)}
+}
+
+// With returns a logger that attaches the given key/value pairs to every
+// record. Use it for values that are constant for a unit of work, such as a
+// traceID or a volumeID, instead of interpolating them into each message.
+func (l Logger) With(args ...any) Logger {
+	return Logger{log: l.unwrap().With(args...)}
+}
+
+// SetLevel changes the emitted level in place, on every logger derived from this
+// one, without recreating it.
+func (l Logger) SetLevel(level Verbosity) error {
+	lvl, err := level.Level()
+	if err != nil {
+		return err
+	}
+
+	l.unwrap().SetLevel(lvl)
+	return nil
+}
+
+// GetSlogLogger returns the underlying logger, for the few APIs that take one
+// directly.
+func (l Logger) GetSlogLogger() *log.Logger {
+	return l.unwrap()
+}
+
+// GetLogger returns a logr view of this logger, for libraries that accept only
+// logr — controller-runtime's manager.Options.Logger in particular.
 func (l Logger) GetLogger() logr.Logger {
-	return l.log
+	return logr.FromSlogHandler(l.unwrap().Handler())
 }
 
+// Error logs at error level. The error is attached as a structured field via
+// log.Err, and the underlying logger appends a full stack trace.
+//
+// This one delegates to the library instead of going through emit, because the
+// stack trace is injected by log.Logger.Error itself. The trace supersedes the
+// "source" field, which the handler drops when a trace is present, so nothing is
+// lost by not fixing up the caller frame here.
 func (l Logger) Error(err error, message string, keysAndValues ...interface{}) {
-	l.log.Error(err, fmt.Sprintf("ERROR %s", message), keysAndValues...)
+	l.unwrap().Error(message, append([]any{log.Err(err)}, keysAndValues...)...)
 }
 
 func (l Logger) Warning(message string, keysAndValues ...interface{}) {
-	l.log.V(warnLvl).Info(fmt.Sprintf("WARNING %s", message), keysAndValues...)
+	l.emit(log.LevelWarn, message, keysAndValues)
 }
 
 func (l Logger) Info(message string, keysAndValues ...interface{}) {
-	l.log.V(infoLvl).Info(fmt.Sprintf("INFO %s", message), keysAndValues...)
+	l.emit(log.LevelInfo, message, keysAndValues)
 }
 
 func (l Logger) Debug(message string, keysAndValues ...interface{}) {
-	l.log.V(debugLvl).Info(fmt.Sprintf("DEBUG %s", message), keysAndValues...)
+	l.emit(log.LevelDebug, message, keysAndValues)
 }
 
+// Trace logs at the trace level, which plain slog does not provide.
 func (l Logger) Trace(message string, keysAndValues ...interface{}) {
-	l.log.V(traceLvl).Info(fmt.Sprintf("TRACE %s", message), keysAndValues...)
+	l.emit(log.LevelTrace, message, keysAndValues)
+}
+
+// emit builds the record by hand so that the "source" field names the call site
+// rather than this file.
+//
+// Calling log.Logger.Info and friends directly would make slog capture the
+// program counter of the wrapper, so every line would report
+// logger/logger.go. The previous klog-based logger avoided that with
+// WithCallDepth(1); this is the slog equivalent.
+func (l Logger) emit(level log.Level, message string, keysAndValues []any) {
+	lg := l.unwrap()
+	ctx := context.Background()
+	slevel := slog.Level(level)
+
+	if !lg.Enabled(ctx, slevel) {
+		return
+	}
+
+	// Skip runtime.Callers, emit itself, and the exported method that called it.
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:])
+
+	record := slog.NewRecord(time.Now(), slevel, message, pcs[0])
+	record.Add(keysAndValues...)
+
+	// The error is not actionable: the handler only fails if the record cannot be
+	// serialised, and there is nowhere left to report that.
+	_ = lg.Handler().Handle(ctx, record)
 }

--- a/images/sds-local-volume-csi/pkg/logger/logger.go
+++ b/images/sds-local-volume-csi/pkg/logger/logger.go
@@ -14,14 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package logger wraps github.com/deckhouse/deckhouse/pkg/log in the small API
-// this module uses.
+// Package logger adapts github.com/deckhouse/deckhouse/pkg/log to this module.
 //
-// The method set (Error/Warning/Info/Debug/Trace) is kept from the previous
-// klog-based implementation so that existing call sites are unaffected, and so
-// is the Verbosity type: LOG_LEVEL is delivered as a number 0..4 both by
-// lib-helm's helm_lib_module_controller_log_level and by the module's own CSI
-// templates, and that contract must not change.
+// Logger embeds *log.Logger rather than wrapping it, so Info/Debug/Warn/Error are
+// the library's own methods. That is deliberate: sloglint and govet's slog
+// analyzer only recognise log/slog and types embedding *slog.Logger, so
+// embedding is what puts every call site in the module under those checks. A
+// hand-written forwarding method would hide them again.
+//
+// Only what the library does not provide is added here: Verbosity parsing for the
+// numeric LOG_LEVEL contract, a Trace level, and Named/With overridden to return
+// this type.
+//
+// LOG_LEVEL is delivered as a number 0..4 both by lib-helm's
+// helm_lib_module_controller_log_level and by the module's own CSI templates, and
+// that contract must not change.
 package logger
 
 import (
@@ -81,55 +88,53 @@ func (v Verbosity) Level() (log.Level, error) {
 	}
 }
 
+// Logger is the module logger.
+//
+// The embedded pointer is what exposes Info, Debug, Warn and Error directly from
+// the library, and what makes those calls visible to the slog linters. Build one
+// with NewLogger, NewLoggerToWriter or NewNop; the zero value has no embedded
+// logger and panics on use.
 type Logger struct {
-	log *log.Logger
+	*log.Logger
 }
 
-// nop backs the zero Logger. The previous logr-based implementation held a
-// logr.Logger by value, whose zero value discards silently, and callers rely on
-// that: a zero Logger must stay a no-op rather than panic.
-var nop = log.NewNop()
-
-// unwrap returns the underlying logger, substituting the discard logger for a
-// zero Logger.
-func (l Logger) unwrap() *log.Logger {
-	if l.log == nil {
-		return nop
-	}
-	return l.log
-}
+// Err wraps an error into the field the library uses for it. Re-exported so that
+// a call site does not have to import pkg/log next to its own log variable:
+//
+//	log.Error("unable to create the volume", logger.Err(err))
+var Err = log.Err
 
 // NewLogger returns a logger emitting at the given verbosity.
-func NewLogger(level Verbosity) (*Logger, error) {
+func NewLogger(level Verbosity) (Logger, error) {
 	lvl, err := level.Level()
 	if err != nil {
-		return nil, err
+		return Logger{}, err
 	}
 
-	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()))}, nil
+	return Logger{log.NewLogger(log.WithLevel(lvl.Level()))}, nil
 }
 
 // NewLoggerToWriter returns a logger writing to w, for tests that want the
 // output attached to their own reporter.
-func NewLoggerToWriter(w io.Writer, level Verbosity) (*Logger, error) {
+func NewLoggerToWriter(w io.Writer, level Verbosity) (Logger, error) {
 	lvl, err := level.Level()
 	if err != nil {
-		return nil, err
+		return Logger{}, err
 	}
 
-	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()), log.WithOutput(w))}, nil
+	return Logger{log.NewLogger(log.WithLevel(lvl.Level()), log.WithOutput(w))}, nil
 }
 
 // NewNop returns a logger that discards everything, for tests that do not care
 // about log output.
-func NewNop() *Logger {
-	return &Logger{log: log.NewNop()}
+func NewNop() Logger {
+	return Logger{log.NewNop()}
 }
 
 // NewLoggerFromSlog adapts an existing pkg/log logger, so that a caller which
 // already built one does not have to reconfigure it.
 func NewLoggerFromSlog(l *log.Logger) Logger {
-	return Logger{log: l}
+	return Logger{l}
 }
 
 // Named appends name to the logger's dotted trace path, e.g. a logger named
@@ -137,92 +142,65 @@ func NewLoggerFromSlog(l *log.Logger) Logger {
 // "local-storage-class-controller.reconcile". Use it instead of hand-writing a
 // "[Component]" prefix into the message.
 func (l Logger) Named(name string) Logger {
-	return Logger{log: l.unwrap().Named(name)}
+	return Logger{l.Logger.Named(name)}
 }
 
 // With returns a logger that attaches the given key/value pairs to every
 // record. Use it for values that are constant for a unit of work, such as a
 // traceID or a volumeID, instead of interpolating them into each message.
 func (l Logger) With(args ...any) Logger {
-	return Logger{log: l.unwrap().With(args...)}
+	return Logger{l.Logger.With(args...)}
 }
 
-// SetLevel changes the emitted level in place, on every logger derived from this
-// one, without recreating it.
-func (l Logger) SetLevel(level Verbosity) error {
+// SetVerbosity changes the emitted level in place, on every logger derived from
+// this one, without recreating it.
+//
+// Named SetVerbosity rather than SetLevel so that it does not shadow the embedded
+// SetLevel, which takes a log.Level instead of the numeric Verbosity.
+func (l Logger) SetVerbosity(level Verbosity) error {
 	lvl, err := level.Level()
 	if err != nil {
 		return err
 	}
 
-	l.unwrap().SetLevel(lvl)
+	l.SetLevel(lvl)
 	return nil
 }
 
 // GetSlogLogger returns the underlying logger, for the few APIs that take one
 // directly.
 func (l Logger) GetSlogLogger() *log.Logger {
-	return l.unwrap()
+	return l.Logger
 }
 
 // GetLogger returns a logr view of this logger, for libraries that accept only
 // logr — controller-runtime's manager.Options.Logger in particular.
 func (l Logger) GetLogger() logr.Logger {
-	return logr.FromSlogHandler(l.unwrap().Handler())
-}
-
-// Error logs at error level. The error is attached as a structured field via
-// log.Err, and the underlying logger appends a full stack trace.
-//
-// This one delegates to the library instead of going through emit, because the
-// stack trace is injected by log.Logger.Error itself. The trace supersedes the
-// "source" field, which the handler drops when a trace is present, so nothing is
-// lost by not fixing up the caller frame here.
-func (l Logger) Error(err error, message string, keysAndValues ...interface{}) {
-	l.unwrap().Error(message, append([]any{log.Err(err)}, keysAndValues...)...)
-}
-
-func (l Logger) Warning(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelWarn, message, keysAndValues)
-}
-
-func (l Logger) Info(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelInfo, message, keysAndValues)
-}
-
-func (l Logger) Debug(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelDebug, message, keysAndValues)
+	return logr.FromSlogHandler(l.Handler())
 }
 
 // Trace logs at the trace level, which plain slog does not provide.
-func (l Logger) Trace(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelTrace, message, keysAndValues)
-}
-
-// emit builds the record by hand so that the "source" field names the call site
-// rather than this file.
 //
-// Calling log.Logger.Info and friends directly would make slog capture the
-// program counter of the wrapper, so every line would report
-// logger/logger.go. The previous klog-based logger avoided that with
-// WithCallDepth(1); this is the slog equivalent.
-func (l Logger) emit(level log.Level, message string, keysAndValues []any) {
-	lg := l.unwrap()
+// Info, Debug, Warn and Error come from the embedded logger, so slog attributes
+// them to their call site by itself. Trace is a method on this type, so the
+// record is built by hand to keep "source" pointing at the caller instead of this
+// file.
+func (l Logger) Trace(message string, args ...any) {
 	ctx := context.Background()
-	slevel := slog.Level(level)
+	level := slog.Level(log.LevelTrace)
 
-	if !lg.Enabled(ctx, slevel) {
+	if !l.Enabled(ctx, level) {
 		return
 	}
 
-	// Skip runtime.Callers, emit itself, and the exported method that called it.
+	// Skip runtime.Callers, Trace itself, and land on the caller.
 	var pcs [1]uintptr
-	runtime.Callers(3, pcs[:])
+	runtime.Callers(2, pcs[:])
 
-	record := slog.NewRecord(time.Now(), slevel, message, pcs[0])
-	record.Add(keysAndValues...)
+	record := slog.NewRecord(time.Now(), level, message, pcs[0])
+	record.Add(args...)
 
 	// The error is not actionable: the handler only fails if the record cannot be
 	// serialised, and there is nowhere left to report that.
-	_ = lg.Handler().Handle(ctx, record)
+	_ = l.Handler().Handle(ctx, record)
 }

--- a/images/sds-local-volume-csi/pkg/logger/logger_test.go
+++ b/images/sds-local-volume-csi/pkg/logger/logger_test.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"bytes"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -28,7 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-func newBufLogger(t *testing.T, level Verbosity) (*Logger, *bytes.Buffer) {
+func newBufLogger(t *testing.T, level Verbosity) (Logger, *bytes.Buffer) {
 	t.Helper()
 
 	buf := &bytes.Buffer{}
@@ -112,8 +113,8 @@ func TestLevelThresholds(t *testing.T) {
 		t.Run(string(tt.level), func(t *testing.T) {
 			l, buf := newBufLogger(t, tt.level)
 
-			l.Error(errors.New("boom"), "an-error")
-			l.Warning("a-warning")
+			l.Error("an-error", Err(errors.New("boom")))
+			l.Warn("a-warning")
 			l.Info("an-info")
 			l.Debug("a-debug")
 			l.Trace("a-trace")
@@ -132,7 +133,7 @@ func TestLevelThresholds(t *testing.T) {
 func TestErrorAttachesErrorAndStackTrace(t *testing.T) {
 	l, buf := newBufLogger(t, TraceLevel)
 
-	l.Error(errors.New("disk on fire"), "unable to create volume", "volumeID", "pvc-123")
+	l.Error("unable to create volume", Err(errors.New("disk on fire")), slog.String("volumeID", "pvc-123"))
 
 	out := buf.String()
 	assert.Contains(t, out, "unable to create volume")
@@ -149,7 +150,7 @@ func TestErrorToleratesNilError(t *testing.T) {
 
 	// Call sites pass whatever they hold; a nil error must not panic.
 	assert.NotPanics(t, func() {
-		l.Error(nil, "something went wrong")
+		l.Error("something went wrong", Err(nil))
 	})
 	assert.Contains(t, buf.String(), "something went wrong")
 }
@@ -196,7 +197,7 @@ func TestSetLevelChangesLevelInPlace(t *testing.T) {
 
 	// Changing the level must affect the live logger, which is what lets the
 	// level be raised without restarting the pod.
-	require.NoError(t, l.SetLevel(DebugLevel))
+	require.NoError(t, l.SetVerbosity(DebugLevel))
 	l.Debug("after")
 	assert.Contains(t, buf.String(), "after")
 }
@@ -208,7 +209,7 @@ func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
 	child.Debug("before")
 	require.NotContains(t, buf.String(), "before")
 
-	require.NoError(t, l.SetLevel(DebugLevel))
+	require.NoError(t, l.SetVerbosity(DebugLevel))
 
 	child.Debug("after")
 	assert.Contains(t, buf.String(), "after")
@@ -216,51 +217,51 @@ func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
 
 func TestSetLevelRejectsInvalidValue(t *testing.T) {
 	l, _ := newBufLogger(t, InfoLevel)
-	assert.Error(t, l.SetLevel(Verbosity("nonsense")))
+	assert.Error(t, l.SetVerbosity(Verbosity("nonsense")))
 }
 
 func TestNopDiscardsEverything(t *testing.T) {
 	l := NewNop()
 
 	assert.NotPanics(t, func() {
-		l.Error(errors.New("boom"), "an-error")
+		l.Error("an-error", Err(errors.New("boom")))
 		l.Info("an-info")
 		l.Trace("a-trace")
 		l.Named("x").With("k", "v").Debug("a-debug")
 	})
 }
 
-// TestZeroLoggerIsANoOp guards the behaviour the previous logr-backed
-// implementation had: tests construct logger.Logger{} directly and must not
-// crash on it.
-func TestZeroLoggerIsANoOp(t *testing.T) {
-	var l Logger
+// TestNopIsUsableEverywhere covers what the zero value used to be relied on for.
+// Embedding *log.Logger means the zero Logger can no longer be a silent no-op, so
+// callers that want one ask for NewNop instead.
+func TestNopIsUsableEverywhere(t *testing.T) {
+	l := NewNop()
 
 	assert.NotPanics(t, func() {
-		l.Error(errors.New("boom"), "an-error")
-		l.Warning("a-warning")
+		l.Error("an-error", Err(errors.New("boom")))
+		l.Warn("a-warning")
 		l.Info("an-info")
 		l.Debug("a-debug")
 		l.Trace("a-trace")
 		l.Named("x").With("k", "v").Info("nested")
 		_ = l.GetLogger()
 		_ = l.GetSlogLogger()
-		_ = l.SetLevel(InfoLevel)
+		_ = l.SetVerbosity(InfoLevel)
 	})
 }
 
-// TestSourceNamesTheCallSite guards against the wrapper attributing every record
-// to itself. Without the manual record construction in emit, "source" would read
-// logger/logger.go for all 300-odd call sites in the module.
+// TestSourceNamesTheCallSite guards caller attribution. Info/Debug/Warn come
+// straight from the embedded logger so slog attributes them itself; Trace is a
+// method on this type and builds its record by hand to achieve the same.
 func TestSourceNamesTheCallSite(t *testing.T) {
 	tests := []struct {
 		name string
-		emit func(l *Logger)
+		emit func(l Logger)
 	}{
-		{name: "Warning", emit: func(l *Logger) { l.Warning("m") }},
-		{name: "Info", emit: func(l *Logger) { l.Info("m") }},
-		{name: "Debug", emit: func(l *Logger) { l.Debug("m") }},
-		{name: "Trace", emit: func(l *Logger) { l.Trace("m") }},
+		{name: "Warn", emit: func(l Logger) { l.Warn("m") }},
+		{name: "Info", emit: func(l Logger) { l.Info("m") }},
+		{name: "Debug", emit: func(l Logger) { l.Debug("m") }},
+		{name: "Trace", emit: func(l Logger) { l.Trace("m") }},
 	}
 
 	for _, tt := range tests {
@@ -282,7 +283,7 @@ func TestSourceNamesTheCallSite(t *testing.T) {
 func TestErrorReportsStackTraceInsteadOfSource(t *testing.T) {
 	l, buf := newBufLogger(t, TraceLevel)
 
-	l.Error(errors.New("boom"), "failed")
+	l.Error("failed", Err(errors.New("boom")))
 
 	out := buf.String()
 	assert.NotContains(t, out, `"source"`)

--- a/images/sds-local-volume-csi/pkg/logger/logger_test.go
+++ b/images/sds-local-volume-csi/pkg/logger/logger_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+func newBufLogger(t *testing.T, level Verbosity) (*Logger, *bytes.Buffer) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	l, err := NewLoggerToWriter(buf, level)
+	require.NoError(t, err)
+	return l, buf
+}
+
+func TestVerbosityLevelMapping(t *testing.T) {
+	// The numeric LOG_LEVEL contract is shared with lib-helm and the CSI
+	// templates; these thresholds must keep matching the previous klog-based
+	// logger, where Warning was V(1), Info V(2), Debug V(3) and Trace V(4).
+	tests := []struct {
+		verbosity Verbosity
+		want      log.Level
+	}{
+		{verbosity: ErrorLevel, want: log.LevelError},
+		{verbosity: WarningLevel, want: log.LevelWarn},
+		{verbosity: InfoLevel, want: log.LevelInfo},
+		{verbosity: DebugLevel, want: log.LevelDebug},
+		{verbosity: TraceLevel, want: log.LevelTrace},
+		// Anything past TRACE stays at TRACE, as before.
+		{verbosity: Verbosity("9"), want: log.LevelTrace},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.verbosity), func(t *testing.T) {
+			got, err := tt.verbosity.Level()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVerbosityRejectsInvalidValues(t *testing.T) {
+	for _, v := range []Verbosity{"", "abc", "-1", "2.5"} {
+		t.Run(string(v), func(t *testing.T) {
+			_, err := v.Level()
+			assert.Error(t, err)
+
+			_, err = NewLogger(v)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestLevelThresholds pins which methods emit at each configured verbosity.
+func TestLevelThresholds(t *testing.T) {
+	tests := []struct {
+		level   Verbosity
+		emitted []string
+		dropped []string
+	}{
+		{
+			level:   ErrorLevel,
+			emitted: []string{"an-error"},
+			dropped: []string{"a-warning", "an-info", "a-debug", "a-trace"},
+		},
+		{
+			level:   WarningLevel,
+			emitted: []string{"an-error", "a-warning"},
+			dropped: []string{"an-info", "a-debug", "a-trace"},
+		},
+		{
+			level:   InfoLevel,
+			emitted: []string{"an-error", "a-warning", "an-info"},
+			dropped: []string{"a-debug", "a-trace"},
+		},
+		{
+			level:   DebugLevel,
+			emitted: []string{"an-error", "a-warning", "an-info", "a-debug"},
+			dropped: []string{"a-trace"},
+		},
+		{
+			level:   TraceLevel,
+			emitted: []string{"an-error", "a-warning", "an-info", "a-debug", "a-trace"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.level), func(t *testing.T) {
+			l, buf := newBufLogger(t, tt.level)
+
+			l.Error(errors.New("boom"), "an-error")
+			l.Warning("a-warning")
+			l.Info("an-info")
+			l.Debug("a-debug")
+			l.Trace("a-trace")
+
+			out := buf.String()
+			for _, msg := range tt.emitted {
+				assert.Contains(t, out, msg, "%s should be emitted at %s", msg, tt.level)
+			}
+			for _, msg := range tt.dropped {
+				assert.NotContains(t, out, msg, "%s should be dropped at %s", msg, tt.level)
+			}
+		})
+	}
+}
+
+func TestErrorAttachesErrorAndStackTrace(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Error(errors.New("disk on fire"), "unable to create volume", "volumeID", "pvc-123")
+
+	out := buf.String()
+	assert.Contains(t, out, "unable to create volume")
+	// The error travels as a structured field rather than being interpolated
+	// into the message.
+	assert.Contains(t, out, "disk on fire")
+	assert.Contains(t, out, "pvc-123")
+	// A stack trace is what the previous logger did not provide.
+	assert.Contains(t, out, "logger.TestErrorAttachesErrorAndStackTrace")
+}
+
+func TestErrorToleratesNilError(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	// Call sites pass whatever they hold; a nil error must not panic.
+	assert.NotPanics(t, func() {
+		l.Error(nil, "something went wrong")
+	})
+	assert.Contains(t, buf.String(), "something went wrong")
+}
+
+func TestNamedBuildsDottedPath(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Named("local-storage-class-controller").Named("reconcile").Info("starting")
+
+	// This is the replacement for hand-written "[Component]" message prefixes.
+	assert.Contains(t, buf.String(), "local-storage-class-controller.reconcile")
+}
+
+func TestNamedDoesNotAffectTheParent(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	child := l.Named("child")
+	child.Info("from-child")
+	l.Info("from-parent")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "child")
+	assert.NotContains(t, lines[1], "child")
+}
+
+func TestWithAttachesFieldsToEveryRecord(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	scoped := l.With("traceID", "abc-123", "volumeID", "pvc-1")
+	scoped.Info("first")
+	scoped.Trace("second")
+
+	out := buf.String()
+	assert.Equal(t, 2, strings.Count(out, "abc-123"))
+	assert.Equal(t, 2, strings.Count(out, "pvc-1"))
+}
+
+func TestSetLevelChangesLevelInPlace(t *testing.T) {
+	l, buf := newBufLogger(t, ErrorLevel)
+
+	l.Debug("before")
+	require.NotContains(t, buf.String(), "before")
+
+	// Changing the level must affect the live logger, which is what lets the
+	// level be raised without restarting the pod.
+	require.NoError(t, l.SetLevel(DebugLevel))
+	l.Debug("after")
+	assert.Contains(t, buf.String(), "after")
+}
+
+func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
+	l, buf := newBufLogger(t, ErrorLevel)
+	child := l.Named("child").With("k", "v")
+
+	child.Debug("before")
+	require.NotContains(t, buf.String(), "before")
+
+	require.NoError(t, l.SetLevel(DebugLevel))
+
+	child.Debug("after")
+	assert.Contains(t, buf.String(), "after")
+}
+
+func TestSetLevelRejectsInvalidValue(t *testing.T) {
+	l, _ := newBufLogger(t, InfoLevel)
+	assert.Error(t, l.SetLevel(Verbosity("nonsense")))
+}
+
+func TestNopDiscardsEverything(t *testing.T) {
+	l := NewNop()
+
+	assert.NotPanics(t, func() {
+		l.Error(errors.New("boom"), "an-error")
+		l.Info("an-info")
+		l.Trace("a-trace")
+		l.Named("x").With("k", "v").Debug("a-debug")
+	})
+}
+
+// TestZeroLoggerIsANoOp guards the behaviour the previous logr-backed
+// implementation had: tests construct logger.Logger{} directly and must not
+// crash on it.
+func TestZeroLoggerIsANoOp(t *testing.T) {
+	var l Logger
+
+	assert.NotPanics(t, func() {
+		l.Error(errors.New("boom"), "an-error")
+		l.Warning("a-warning")
+		l.Info("an-info")
+		l.Debug("a-debug")
+		l.Trace("a-trace")
+		l.Named("x").With("k", "v").Info("nested")
+		_ = l.GetLogger()
+		_ = l.GetSlogLogger()
+		_ = l.SetLevel(InfoLevel)
+	})
+}
+
+// TestSourceNamesTheCallSite guards against the wrapper attributing every record
+// to itself. Without the manual record construction in emit, "source" would read
+// logger/logger.go for all 300-odd call sites in the module.
+func TestSourceNamesTheCallSite(t *testing.T) {
+	tests := []struct {
+		name string
+		emit func(l *Logger)
+	}{
+		{name: "Warning", emit: func(l *Logger) { l.Warning("m") }},
+		{name: "Info", emit: func(l *Logger) { l.Info("m") }},
+		{name: "Debug", emit: func(l *Logger) { l.Debug("m") }},
+		{name: "Trace", emit: func(l *Logger) { l.Trace("m") }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, buf := newBufLogger(t, TraceLevel)
+
+			tt.emit(l)
+
+			out := buf.String()
+			assert.Contains(t, out, "logger_test.go")
+			assert.NotContains(t, out, "logger/logger.go")
+		})
+	}
+}
+
+// TestErrorReportsStackTraceInsteadOfSource documents the one exception: the
+// handler drops "source" when a stack trace is attached, so Error does not need
+// caller fix-up.
+func TestErrorReportsStackTraceInsteadOfSource(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Error(errors.New("boom"), "failed")
+
+	out := buf.String()
+	assert.NotContains(t, out, `"source"`)
+	assert.Contains(t, out, "stacktrace")
+}
+
+func TestGetLoggerBridgesToLogr(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	// controller-runtime takes a logr.Logger; records written through it must
+	// land in the same output with the same level handling.
+	l.GetLogger().Info("from-logr", "k", "v")
+
+	out := buf.String()
+	assert.Contains(t, out, "from-logr")
+	assert.Contains(t, out, "\"k\":\"v\"")
+}

--- a/images/sds-local-volume-csi/pkg/utils/func.go
+++ b/images/sds-local-volume-csi/pkg/utils/func.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"time"
 
@@ -52,8 +53,8 @@ const (
 func CreateLVMLogicalVolumeSnapshot(
 	ctx context.Context,
 	kc client.Client,
-	log *logger.Logger,
-	traceID, name string,
+	log logger.Logger,
+	name string,
 	lvmLogicalVolumeSnapshotSpec snc.LVMLogicalVolumeSnapshotSpec,
 ) (*snc.LVMLogicalVolumeSnapshot, error) {
 	llvs := &snc.LVMLogicalVolumeSnapshot{
@@ -65,39 +66,39 @@ func CreateLVMLogicalVolumeSnapshot(
 		Spec: lvmLogicalVolumeSnapshotSpec,
 	}
 
-	log.Trace(fmt.Sprintf("[CreateLVMLogicalVolumeSnapshot][traceID:%s][volumeID:%s] LVMLogicalVolumeSnapshot: %+v", traceID, name, llvs))
+	log.Trace("built the LVMLogicalVolumeSnapshot", "llvs", fmt.Sprintf("%+v", llvs))
 
 	return llvs, kc.Create(ctx, llvs)
 }
 
-func DeleteLVMLogicalVolumeSnapshot(ctx context.Context, kc client.Client, log *logger.Logger, traceID, lvmLogicalVolumeSnapshotName string) error {
+func DeleteLVMLogicalVolumeSnapshot(ctx context.Context, kc client.Client, log logger.Logger, lvmLogicalVolumeSnapshotName string) error {
 	var err error
 
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolumeSnapshot][traceID:%s][volumeID:%s] Trying to find LVMLogicalVolumeSnapshot", traceID, lvmLogicalVolumeSnapshotName))
+	log.Trace("Trying to find LVMLogicalVolumeSnapshot")
 	llvs, err := GetLVMLogicalVolumeSnapshot(ctx, kc, lvmLogicalVolumeSnapshotName, "")
 	if err != nil {
 		return fmt.Errorf("get LVMLogicalVolumeSnapshot %s: %w", lvmLogicalVolumeSnapshotName, err)
 	}
 
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolumeSnapshot][traceID:%s][volumeID:%s] LVMLogicalVolumeSnapshot found: %+v (status: %+v)", traceID, lvmLogicalVolumeSnapshotName, llvs, llvs.Status))
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolumeSnapshot][traceID:%s][volumeID:%s] Removing finalizer %s if exists", traceID, lvmLogicalVolumeSnapshotName, SDSLocalVolumeCSIFinalizer))
+	log.Trace("found the LVMLogicalVolumeSnapshot", "llvs", fmt.Sprintf("%+v", llvs), "status", fmt.Sprintf("%+v", llvs.Status))
+	log.Trace("removing the finalizer if present", "finalizer", SDSLocalVolumeCSIFinalizer)
 
 	removed, err := removeLLVSFinalizerIfExist(ctx, kc, log, llvs, SDSLocalVolumeCSIFinalizer)
 	if err != nil {
 		return fmt.Errorf("remove finalizers from DeleteLVMLogicalVolumeSnapshot %s: %w", lvmLogicalVolumeSnapshotName, err)
 	}
 	if removed {
-		log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolumeSnapshot][traceID:%s][volumeID:%s] finalizer %s removed from LVMLogicalVolumeSnapshot %s", traceID, lvmLogicalVolumeSnapshotName, SDSLocalVolumeCSIFinalizer, lvmLogicalVolumeSnapshotName))
+		log.Trace("removed the finalizer from the LVMLogicalVolumeSnapshot", "finalizer", SDSLocalVolumeCSIFinalizer, "llvsName", lvmLogicalVolumeSnapshotName)
 	} else {
-		log.Warning(fmt.Sprintf("[DeleteLVMLogicalVolumeSnapshot][traceID:%s][volumeID:%s] finalizer %s not found in LVMLogicalVolumeSnapshot %s", traceID, lvmLogicalVolumeSnapshotName, SDSLocalVolumeCSIFinalizer, lvmLogicalVolumeSnapshotName))
+		log.Warn("the finalizer was not present on the LVMLogicalVolumeSnapshot", "finalizer", SDSLocalVolumeCSIFinalizer, "llvsName", lvmLogicalVolumeSnapshotName)
 	}
 
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolumeSnapshot][traceID:%s][volumeID:%s] Trying to delete LVMLogicalVolumeSnapshot", traceID, lvmLogicalVolumeSnapshotName))
+	log.Trace("Trying to delete LVMLogicalVolumeSnapshot")
 	err = kc.Delete(ctx, llvs)
 	return err
 }
 
-func removeLLVSFinalizerIfExist(ctx context.Context, kc client.Client, log *logger.Logger, llvs *snc.LVMLogicalVolumeSnapshot, finalizer string) (bool, error) {
+func removeLLVSFinalizerIfExist(ctx context.Context, kc client.Client, log logger.Logger, llvs *snc.LVMLogicalVolumeSnapshot, finalizer string) (bool, error) {
 	for attempt := 0; attempt < KubernetesAPIRequestLimit; attempt++ {
 		removed := false
 		for i, val := range llvs.Finalizers {
@@ -112,7 +113,7 @@ func removeLLVSFinalizerIfExist(ctx context.Context, kc client.Client, log *logg
 			return false, nil
 		}
 
-		log.Trace(fmt.Sprintf("[removeLLVSFinalizerIfExist] removing finalizer %s from LVMLogicalVolumeSnapshot %s", finalizer, llvs.Name))
+		log.Trace("removing the finalizer from the LVMLogicalVolumeSnapshot", "finalizer", finalizer, "llvsName", llvs.Name)
 		err := kc.Update(ctx, llvs)
 		if err == nil {
 			return true, nil
@@ -123,7 +124,7 @@ func removeLLVSFinalizerIfExist(ctx context.Context, kc client.Client, log *logg
 		}
 
 		if attempt < KubernetesAPIRequestLimit-1 {
-			log.Trace(fmt.Sprintf("[removeLLVSFinalizerIfExist] conflict while updating LVMLogicalVolumeSnapshot %s, retrying...", llvs.Name))
+			log.Trace("conflict while updating the LVMLogicalVolumeSnapshot, retrying", "llvsName", llvs.Name)
 			select {
 			case <-ctx.Done():
 				return false, ctx.Err()
@@ -145,17 +146,16 @@ func removeLLVSFinalizerIfExist(ctx context.Context, kc client.Client, log *logg
 func WaitForLLVSStatusUpdate(
 	ctx context.Context,
 	kc client.Client,
-	log *logger.Logger,
-	traceID string,
+	log logger.Logger,
 	lvmLogicalVolumeSnapshotName string,
 ) (int, error) {
 	var attemptCounter int
-	log.Info(fmt.Sprintf("[WaitForLLVSStatusUpdate][traceID:%s][volumeID:%s] Waiting for LVM Logical Volume Snapshot status update", traceID, lvmLogicalVolumeSnapshotName))
+	log.Info("Waiting for LVM Logical Volume Snapshot status update")
 	for {
 		attemptCounter++
 		select {
 		case <-ctx.Done():
-			log.Warning(fmt.Sprintf("[WaitForLLVSStatusUpdate][traceID:%s][volumeID:%s] context done. Failed to wait for LVM Logical Volume Snapshot status update", traceID, lvmLogicalVolumeSnapshotName))
+			log.Warn("context done. Failed to wait for LVM Logical Volume Snapshot status update")
 			return attemptCounter, ctx.Err()
 		default:
 			time.Sleep(500 * time.Millisecond)
@@ -167,11 +167,11 @@ func WaitForLLVSStatusUpdate(
 		}
 
 		if attemptCounter%10 == 0 {
-			log.Info(fmt.Sprintf("[WaitForLLVSStatusUpdate][traceID:%s][volumeID:%s] Attempt: %d,LVM Logical Volume Snapshot: %+v", traceID, lvmLogicalVolumeSnapshotName, attemptCounter, llvs))
+			log.Info("polling the LVMLogicalVolumeSnapshot", "attempt", attemptCounter, "llvs", fmt.Sprintf("%+v", llvs))
 		}
 
 		if llvs.Status != nil {
-			log.Trace(fmt.Sprintf("[WaitForLLVSStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume Snapshot status: %+v, full LVMLogicalVolumeSnapshot resource: %+v", traceID, lvmLogicalVolumeSnapshotName, attemptCounter, llvs.Status, llvs))
+			log.Trace("polled the LVMLogicalVolumeSnapshot", "attempt", attemptCounter, "status", fmt.Sprintf("%+v", llvs.Status), "llvs", fmt.Sprintf("%+v", llvs))
 
 			if llvs.DeletionTimestamp != nil {
 				return attemptCounter, fmt.Errorf("failed to create LVM logical volume snapshot on node for LVMLogicalVolumeSnapshot %s, reason: LVMLogicalVolumeSnapshot is being deleted", lvmLogicalVolumeSnapshotName)
@@ -182,10 +182,10 @@ func WaitForLLVSStatusUpdate(
 			}
 
 			if llvs.Status.Phase == LLVSStatusCreated {
-				log.Trace(fmt.Sprintf("[WaitForLLVSStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume Snapshot created but size does not match the requested size yet. Waiting...", traceID, lvmLogicalVolumeSnapshotName, attemptCounter))
+				log.Trace("the LVMLogicalVolumeSnapshot is created but its size does not match the request yet, waiting", "attempt", attemptCounter)
 				return attemptCounter, nil
 			}
-			log.Trace(fmt.Sprintf("[WaitForLLVSStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume Snapshot status is not 'Created' yet. Waiting...", traceID, lvmLogicalVolumeSnapshotName, attemptCounter))
+			log.Trace("the LVMLogicalVolumeSnapshot is not in the Created phase yet, waiting", "attempt", attemptCounter)
 		}
 	}
 }
@@ -201,47 +201,47 @@ func GetLVMLogicalVolumeSnapshot(ctx context.Context, kc client.Client, lvmLogic
 	return &llvs, err
 }
 
-func GetLSCBeforeLLVDelete(ctx context.Context, cl client.Client, log logger.Logger, volumeID, traceID string) (*slv.LocalStorageClass, error) {
-	log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] Fetching PersistentVolume with VolumeId: %s", traceID, volumeID))
+func GetLSCBeforeLLVDelete(ctx context.Context, cl client.Client, log logger.Logger, volumeID string) (*slv.LocalStorageClass, error) {
+	log.Info("fetching the PersistentVolume", "volumeID", volumeID)
 	var pv corev1.PersistentVolume
 	if err := cl.Get(ctx, client.ObjectKey{Name: volumeID}, &pv); err != nil {
 		if kerrors.IsNotFound(err) {
-			log.Error(err, fmt.Sprintf("[DeleteVolume][traceID:%s] PersistentVolume %s not found: %v", traceID, volumeID, err))
+			log.Error("the PersistentVolume was not found", logger.Err(err), slog.String("volumeID", volumeID))
 			return nil, status.Errorf(codes.NotFound, "PersistentVolume %s not found: %v", volumeID, err)
 		}
-		log.Error(err, "[DeleteVolume][traceID:%s] Failed to fetch PersistentVolume: %v", traceID, err)
+		log.Error("unable to fetch the PersistentVolume", logger.Err(err), slog.String("volumeID", volumeID))
 		return nil, status.Errorf(codes.Internal, "Failed to fetch PersistentVolume %s: %v", volumeID, err)
 	}
 
-	log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] PersistentVolume %s successfully fetched", traceID, volumeID))
+	log.Info("fetched the PersistentVolume", "volumeID", volumeID)
 
 	storageClassName := pv.Spec.StorageClassName
 	if storageClassName == "" {
-		log.Error(nil, "[DeleteVolume][traceID:%s] PersistentVolume %s does not have a StorageClassName defined", traceID, volumeID)
+		log.Error("the PersistentVolume has no StorageClassName defined", slog.String("volumeID", volumeID))
 		return nil, status.Error(codes.InvalidArgument, "PersistentVolume does not have a StorageClassName defined")
 	}
-	log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] StorageClassName for PersistentVolume %s: %s", traceID, volumeID, storageClassName))
+	log.Info("resolved the PersistentVolume storage class", "volumeID", volumeID, "storageClassName", storageClassName)
 
-	log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] Fetching LocalStorageClass with name: %s", traceID, storageClassName))
+	log.Info("fetching the LocalStorageClass", "storageClassName", storageClassName)
 
 	var localStorageClass slv.LocalStorageClass
 
 	err := cl.Get(ctx, client.ObjectKey{Name: storageClassName}, &localStorageClass)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			log.Error(err, fmt.Sprintf("[DeleteVolume][traceID:%s] LocalStorageClass %s not found: %v", traceID, storageClassName, err))
+			log.Error("the LocalStorageClass was not found", logger.Err(err), slog.String("storageClassName", storageClassName))
 		} else {
-			log.Error(err, fmt.Sprintf("[DeleteVolume][traceID:%s] Error fetching LocalStorageClass %s: %v", traceID, storageClassName, err))
+			log.Error("unable to fetch the LocalStorageClass", logger.Err(err), slog.String("storageClassName", storageClassName))
 			return nil, status.Errorf(codes.Internal, "Failed to fetch LocalStorageClass: %v", err)
 		}
 	} else {
-		log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] Successfully fetched LocalStorageClass: %s", traceID, storageClassName))
+		log.Info("fetched the LocalStorageClass", "storageClassName", storageClassName)
 	}
 
 	return &localStorageClass, nil
 }
 
-func CreateLVMLogicalVolume(ctx context.Context, kc client.Client, log *logger.Logger, traceID, name string, lvmLogicalVolumeSpec snc.LVMLogicalVolumeSpec) (*snc.LVMLogicalVolume, error) {
+func CreateLVMLogicalVolume(ctx context.Context, kc client.Client, log logger.Logger, name string, lvmLogicalVolumeSpec snc.LVMLogicalVolumeSpec) (*snc.LVMLogicalVolume, error) {
 	var err error
 	llv := &snc.LVMLogicalVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -252,16 +252,16 @@ func CreateLVMLogicalVolume(ctx context.Context, kc client.Client, log *logger.L
 		Spec: lvmLogicalVolumeSpec,
 	}
 
-	log.Trace(fmt.Sprintf("[CreateLVMLogicalVolume][traceID:%s][volumeID:%s] LVMLogicalVolume: %+v", traceID, name, llv))
+	log.Trace("built the LVMLogicalVolume", "llv", fmt.Sprintf("%+v", llv))
 
 	err = kc.Create(ctx, llv)
 	return llv, err
 }
 
-func DeleteLVMLogicalVolume(ctx context.Context, kc client.Client, log *logger.Logger, traceID, lvmLogicalVolumeName, volumeCleanup string) error {
+func DeleteLVMLogicalVolume(ctx context.Context, kc client.Client, log logger.Logger, lvmLogicalVolumeName, volumeCleanup string) error {
 	var err error
 
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolume][traceID:%s][volumeID:%s] Trying to find LVMLogicalVolume", traceID, lvmLogicalVolumeName))
+	log.Trace("Trying to find LVMLogicalVolume")
 	llv, err := GetLVMLogicalVolume(ctx, kc, lvmLogicalVolumeName, "")
 	if err != nil {
 		return fmt.Errorf("get LVMLogicalVolume %s: %w", lvmLogicalVolumeName, err)
@@ -277,20 +277,20 @@ func DeleteLVMLogicalVolume(ctx context.Context, kc client.Client, log *logger.L
 		return fmt.Errorf("update LVMLogicalVolume %s: %w", lvmLogicalVolumeName, err)
 	}
 
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolume][traceID:%s][volumeID:%s] LVMLogicalVolume found: %+v (status: %+v)", traceID, lvmLogicalVolumeName, llv, llv.Status))
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolume][traceID:%s][volumeID:%s] Removing finalizer %s if exists", traceID, lvmLogicalVolumeName, SDSLocalVolumeCSIFinalizer))
+	log.Trace("found the LVMLogicalVolume", "llv", fmt.Sprintf("%+v", llv), "status", fmt.Sprintf("%+v", llv.Status))
+	log.Trace("removing the finalizer if present", "finalizer", SDSLocalVolumeCSIFinalizer)
 
 	removed, err := removeLLVFinalizerIfExist(ctx, kc, log, llv, SDSLocalVolumeCSIFinalizer)
 	if err != nil {
 		return fmt.Errorf("remove finalizers from LVMLogicalVolume %s: %w", lvmLogicalVolumeName, err)
 	}
 	if removed {
-		log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolume][traceID:%s][volumeID:%s] finalizer %s removed from LVMLogicalVolume %s", traceID, lvmLogicalVolumeName, SDSLocalVolumeCSIFinalizer, lvmLogicalVolumeName))
+		log.Trace("removed the finalizer from the LVMLogicalVolume", "finalizer", SDSLocalVolumeCSIFinalizer, "llvName", lvmLogicalVolumeName)
 	} else {
-		log.Warning(fmt.Sprintf("[DeleteLVMLogicalVolume][traceID:%s][volumeID:%s] finalizer %s not found in LVMLogicalVolume %s", traceID, lvmLogicalVolumeName, SDSLocalVolumeCSIFinalizer, lvmLogicalVolumeName))
+		log.Warn("the finalizer was not present on the LVMLogicalVolume", "finalizer", SDSLocalVolumeCSIFinalizer, "llvName", lvmLogicalVolumeName)
 	}
 
-	log.Trace(fmt.Sprintf("[DeleteLVMLogicalVolume][traceID:%s][volumeID:%s] Trying to delete LVMLogicalVolume", traceID, lvmLogicalVolumeName))
+	log.Trace("Trying to delete LVMLogicalVolume")
 	err = kc.Delete(ctx, llv)
 	return err
 }
@@ -300,9 +300,9 @@ func DeleteLVMLogicalVolume(ctx context.Context, kc client.Client, log *logger.L
 // that very object. Callers need the resulting size, so returning the resource
 // they waited for saves them a second GET and closes the window in which the
 // status could change between the wait and the re-read.
-func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logger, traceID, lvmLogicalVolumeName, namespace string, llvSize, extentSize resource.Quantity) (*snc.LVMLogicalVolume, int, error) {
+func WaitForStatusUpdate(ctx context.Context, kc client.Client, log logger.Logger, lvmLogicalVolumeName, namespace string, llvSize, extentSize resource.Quantity) (*snc.LVMLogicalVolume, int, error) {
 	var attemptCounter int
-	log.Info(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Waiting for LVM Logical Volume status update", traceID, lvmLogicalVolumeName))
+	log.Info("Waiting for LVM Logical Volume status update")
 
 	alignedSize, err := AlignSizeToExtent(llvSize, extentSize)
 	if err != nil {
@@ -313,7 +313,7 @@ func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logg
 		attemptCounter++
 		select {
 		case <-ctx.Done():
-			log.Warning(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] context done. Failed to wait for LVM Logical Volume status update", traceID, lvmLogicalVolumeName))
+			log.Warn("context done. Failed to wait for LVM Logical Volume status update")
 			return nil, attemptCounter, ctx.Err()
 		default:
 			time.Sleep(500 * time.Millisecond)
@@ -325,11 +325,11 @@ func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logg
 		}
 
 		if attemptCounter%10 == 0 {
-			log.Info(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Attempt: %d, LVM Logical Volume: %+v; alignedSize=%s", traceID, lvmLogicalVolumeName, attemptCounter, llv, alignedSize.String()))
+			log.Info("polling the LVMLogicalVolume", "attempt", attemptCounter, "llv", fmt.Sprintf("%+v", llv), "alignedSize", alignedSize.String())
 		}
 
 		if llv.Status != nil {
-			log.Trace(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume status: %+v, full LVMLogicalVolume resource: %+v", traceID, lvmLogicalVolumeName, attemptCounter, llv.Status, llv))
+			log.Trace("polled the LVMLogicalVolume", "attempt", attemptCounter, "status", fmt.Sprintf("%+v", llv.Status), "llv", fmt.Sprintf("%+v", llv))
 
 			if llv.DeletionTimestamp != nil {
 				return nil, attemptCounter, fmt.Errorf("failed to create LVM logical volume on node for LVMLogicalVolume %s, reason: LVMLogicalVolume is being deleted", lvmLogicalVolumeName)
@@ -343,9 +343,9 @@ func WaitForStatusUpdate(ctx context.Context, kc client.Client, log *logger.Logg
 				if llv.Status.ActualSize.Value() >= alignedSize.Value() {
 					return llv, attemptCounter, nil
 				}
-				log.Trace(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume created but size does not match the requested size yet. Waiting...", traceID, lvmLogicalVolumeName, attemptCounter))
+				log.Trace("the LVMLogicalVolume is created but its size does not match the request yet, waiting", "attempt", attemptCounter)
 			} else {
-				log.Trace(fmt.Sprintf("[WaitForStatusUpdate][traceID:%s][volumeID:%s] Attempt %d, LVM Logical Volume status is not 'Created' yet. Waiting...", traceID, lvmLogicalVolumeName, attemptCounter))
+				log.Trace("the LVMLogicalVolume is not in the Created phase yet, waiting", "attempt", attemptCounter)
 			}
 		}
 	}
@@ -455,13 +455,13 @@ func ExpandLVMLogicalVolume(ctx context.Context, kc client.Client, llv *snc.LVML
 func GetStorageClassLVGsAndParameters(
 	ctx context.Context,
 	kc client.Client,
-	log *logger.Logger,
+	log logger.Logger,
 	storageClassLVGParametersString string,
 ) (storageClassLVGs []snc.LVMVolumeGroup, storageClassLVGParametersMap map[string]string, err error) {
 	var storageClassLVGParametersList LVMVolumeGroups
 	err = yaml.Unmarshal([]byte(storageClassLVGParametersString), &storageClassLVGParametersList)
 	if err != nil {
-		log.Error(err, "unmarshal yaml lvmVolumeGroup")
+		log.Error("unmarshal yaml lvmVolumeGroup", logger.Err(err))
 		return nil, nil, err
 	}
 
@@ -469,7 +469,7 @@ func GetStorageClassLVGsAndParameters(
 	for _, v := range storageClassLVGParametersList {
 		storageClassLVGParametersMap[v.Name] = v.Thin.PoolName
 	}
-	log.Info(fmt.Sprintf("[GetStorageClassLVGs] StorageClass LVM volume groups parameters map: %+v", storageClassLVGParametersMap))
+	log.Info("parsed the storage class LVMVolumeGroup parameters", "parameters", fmt.Sprintf("%+v", storageClassLVGParametersMap))
 
 	lvgs, err := GetLVGList(ctx, kc)
 	if err != nil {
@@ -477,17 +477,17 @@ func GetStorageClassLVGsAndParameters(
 	}
 
 	for _, lvg := range lvgs.Items {
-		log.Trace(fmt.Sprintf("[GetStorageClassLVGs] process lvg: %+v", lvg))
+		log.Trace("processing an LVMVolumeGroup", "lvg", fmt.Sprintf("%+v", lvg))
 
 		_, ok := storageClassLVGParametersMap[lvg.Name]
 		if ok {
-			log.Info(fmt.Sprintf("[GetStorageClassLVGs] found lvg from storage class: %s", lvg.Name))
+			log.Info("matched an LVMVolumeGroup from the storage class", "lvgName", lvg.Name)
 			if len(lvg.Status.Nodes) > 0 {
-				log.Info(fmt.Sprintf("[GetStorageClassLVGs] lvg.Status.Nodes[0].Name: %s", lvg.Status.Nodes[0].Name))
+				log.Info("resolved the LVMVolumeGroup node", "nodeName", lvg.Status.Nodes[0].Name)
 			}
 			storageClassLVGs = append(storageClassLVGs, lvg)
 		} else {
-			log.Trace(fmt.Sprintf("[GetStorageClassLVGs] skip lvg: %s", lvg.Name))
+			log.Trace("skipping an LVMVolumeGroup that is not in the storage class", "lvgName", lvg.Name)
 		}
 	}
 
@@ -500,7 +500,7 @@ func GetLVGList(ctx context.Context, kc client.Client) (*snc.LVMVolumeGroupList,
 }
 
 func GetLLVSpec(
-	log *logger.Logger,
+	log logger.Logger,
 	lvName string,
 	selectedLVG snc.LVMVolumeGroup,
 	storageClassLVGParametersMap map[string]string,
@@ -523,7 +523,7 @@ func GetLLVSpec(
 		lvmLogicalVolumeSpec.Thin = &snc.LVMLogicalVolumeThinSpec{
 			PoolName: storageClassLVGParametersMap[selectedLVG.Name],
 		}
-		log.Info(fmt.Sprintf("[GetLLVSpec] Thin pool name: %s", lvmLogicalVolumeSpec.Thin.PoolName))
+		log.Info("resolved the thin pool", "thinPoolName", lvmLogicalVolumeSpec.Thin.PoolName)
 	case internal.LVMTypeThick:
 		if contiguous {
 			lvmLogicalVolumeSpec.Thick = &snc.LVMLogicalVolumeThickSpec{
@@ -531,14 +531,14 @@ func GetLLVSpec(
 			}
 		}
 
-		log.Info(fmt.Sprintf("[GetLLVSpec] Thick contiguous: %t", contiguous))
+		log.Info("resolved thick contiguous", "contiguous", contiguous)
 	}
 
 	if volumeCleanup != "" {
 		lvmLogicalVolumeSpec.VolumeCleanup = &volumeCleanup
 	}
 
-	log.Info(fmt.Sprintf("[GetLLVSpec] volumeCleanup: %s", volumeCleanup))
+	log.Info("resolved volume cleanup", "volumeCleanup", volumeCleanup)
 
 	return lvmLogicalVolumeSpec
 }
@@ -574,7 +574,7 @@ func SelectLVGByActualNameOnTheNode(storageClassLVGs []snc.LVMVolumeGroup, nodeN
 	return nil, fmt.Errorf("[SelectLVG] no LVMVolumeGroup found with actualNameOnTheNode %s on node %s", actualNameOnTheNode, nodeName)
 }
 
-func removeLLVFinalizerIfExist(ctx context.Context, kc client.Client, log *logger.Logger, llv *snc.LVMLogicalVolume, finalizer string) (bool, error) {
+func removeLLVFinalizerIfExist(ctx context.Context, kc client.Client, log logger.Logger, llv *snc.LVMLogicalVolume, finalizer string) (bool, error) {
 	for attempt := 0; attempt < KubernetesAPIRequestLimit; attempt++ {
 		removed := false
 		for i, val := range llv.Finalizers {
@@ -589,7 +589,7 @@ func removeLLVFinalizerIfExist(ctx context.Context, kc client.Client, log *logge
 			return false, nil
 		}
 
-		log.Trace(fmt.Sprintf("[removeLLVFinalizerIfExist] removing finalizer %s from LVMLogicalVolume %s", finalizer, llv.Name))
+		log.Trace("removing the finalizer from the LVMLogicalVolume", "finalizer", finalizer, "llvName", llv.Name)
 		err := kc.Update(ctx, llv)
 		if err == nil {
 			return true, nil
@@ -600,7 +600,7 @@ func removeLLVFinalizerIfExist(ctx context.Context, kc client.Client, log *logge
 		}
 
 		if attempt < KubernetesAPIRequestLimit-1 {
-			log.Trace(fmt.Sprintf("[removeLLVFinalizerIfExist] conflict while updating LVMLogicalVolume %s, retrying...", llv.Name))
+			log.Trace("conflict while updating the LVMLogicalVolume, retrying", "llvName", llv.Name)
 			select {
 			case <-ctx.Done():
 				return false, ctx.Err()

--- a/images/sds-local-volume-csi/pkg/utils/func.go
+++ b/images/sds-local-volume-csi/pkg/utils/func.go
@@ -213,7 +213,7 @@ func GetLSCBeforeLLVDelete(ctx context.Context, cl client.Client, log logger.Log
 		return nil, status.Errorf(codes.Internal, "Failed to fetch PersistentVolume %s: %v", volumeID, err)
 	}
 
-	log.Info("[DeleteVolume][traceID:%s] PersistentVolume %s successfully fetched", traceID, volumeID)
+	log.Info(fmt.Sprintf("[DeleteVolume][traceID:%s] PersistentVolume %s successfully fetched", traceID, volumeID))
 
 	storageClassName := pv.Spec.StorageClassName
 	if storageClassName == "" {

--- a/images/sds-local-volume-csi/pkg/utils/node_store_maganer_test.go
+++ b/images/sds-local-volume-csi/pkg/utils/node_store_maganer_test.go
@@ -53,7 +53,7 @@ func TestNodeStoreManager(t *testing.T) {
 				},
 			}
 			store := &Store{
-				Log: &logger.Logger{},
+				Log: logger.NewNop(),
 				NodeStorage: mountutils.SafeFormatAndMount{
 					Interface: f,
 				},
@@ -76,7 +76,7 @@ func TestNodeStoreManager(t *testing.T) {
 				},
 			}
 			store := &Store{
-				Log: &logger.Logger{},
+				Log: logger.NewNop(),
 				NodeStorage: mountutils.SafeFormatAndMount{
 					Interface: f,
 				},
@@ -99,7 +99,7 @@ func TestNodeStoreManager(t *testing.T) {
 				},
 			}
 			store := &Store{
-				Log: &logger.Logger{},
+				Log: logger.NewNop(),
 				NodeStorage: mountutils.SafeFormatAndMount{
 					Interface: f,
 				},

--- a/images/sds-local-volume-csi/pkg/utils/node_store_manager.go
+++ b/images/sds-local-volume-csi/pkg/utils/node_store_manager.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strings"
@@ -42,11 +43,11 @@ type NodeStoreManager interface {
 }
 
 type Store struct {
-	Log         *logger.Logger
+	Log         logger.Logger
 	NodeStorage mountutils.SafeFormatAndMount
 }
 
-func NewStore(logger *logger.Logger) *Store {
+func NewStore(logger logger.Logger) *Store {
 	return &Store{
 		Log: logger,
 		NodeStorage: mountutils.SafeFormatAndMount{
@@ -57,15 +58,11 @@ func NewStore(logger *logger.Logger) *Store {
 }
 
 func (s *Store) NodeStageVolumeFS(source, target string, fsType string, mountOpts []string, formatOpts []string, lvmType, lvmThinPoolName string) error {
-	s.Log.Trace(" ----== Start NodeStageVolumeFS ==---- ")
+	log := s.Log.Named("NodeStageVolumeFS").With("source", source, "target", target)
 
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ Format options ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
-	s.Log.Trace(fmt.Sprintf("[format] params device=%s fs=%s formatOptions=%v", source, fsType, formatOpts))
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ Format options ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
+	log.Trace("format parameters", "fsType", fsType, "formatOptions", formatOpts)
 
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ Mount options ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
-	s.Log.Trace(fmt.Sprintf("[mount] params source=%s target=%s fs=%s mountOptions=%v", source, target, fsType, mountOpts))
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ Mount options ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
+	log.Trace("mount parameters", "fsType", fsType, "mountOptions", mountOpts)
 
 	info, err := os.Stat(source)
 	if err != nil {
@@ -76,73 +73,59 @@ func (s *Store) NodeStageVolumeFS(source, target string, fsType string, mountOpt
 		return fmt.Errorf("[NewMount] path %s is not a device", source)
 	}
 
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ MODE SOURCE ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
-	s.Log.Trace(info.Mode().String())
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ MODE SOURCE  ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
+	log.Trace("source mode", "mode", info.Mode().String())
 
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ FS MOUNT ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
-	s.Log.Trace("-----------------== start MkdirAll ==-----------------")
-	s.Log.Trace("mkdir create dir =" + target)
 	exists, err := s.PathExists(target)
 	if err != nil {
 		return fmt.Errorf("[PathExists] could not check if target directory %s exists: %w", target, err)
 	}
 	if !exists {
-		s.Log.Debug(fmt.Sprintf("Creating target directory %s", target))
+		log.Debug("creating the target directory")
 		if err := os.MkdirAll(target, os.FileMode(0755)); err != nil {
 			return fmt.Errorf("[MkdirAll] could not create target directory %s: %w", target, err)
 		}
 	}
-	s.Log.Trace("-----------------== stop MkdirAll ==-----------------")
 
 	isMountPoint, err := s.NodeStorage.IsMountPoint(target)
 	if err != nil {
 		return fmt.Errorf("[s.NodeStorage.IsMountPoint] unable to determine mount status of %s: %w", target, err)
 	}
 
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ isMountPoint ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
-	s.Log.Trace(fmt.Sprintf("%t", isMountPoint))
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ isMountPoint  ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
+	log.Trace("checked the target", "isMountPoint", isMountPoint)
 
 	if isMountPoint {
 		mapperSourcePath := toMapperPath(source)
-		s.Log.Trace(fmt.Sprintf("Target %s is a mount point. Checking if it is already mounted to source %s or %s", target, source, mapperSourcePath))
+		log.Trace("the target is a mount point, checking whether it already points at the source", "mapperSourcePath", mapperSourcePath)
 
 		mountedDevicePath, _, err := mountutils.GetDeviceNameFromMount(s.NodeStorage.Interface, target)
 		if err != nil {
 			return fmt.Errorf("failed to find the device mounted at %s: %w", target, err)
 		}
-		s.Log.Trace(fmt.Sprintf("Found device mounted at %s: %s", target, mountedDevicePath))
+		log.Trace("found the device mounted at the target", "mountedDevicePath", mountedDevicePath)
 
 		if mountedDevicePath != source && mountedDevicePath != mapperSourcePath {
 			return fmt.Errorf("target %s is a mount point and is not mounted to source %s or %s", target, source, mapperSourcePath)
 		}
 
-		s.Log.Trace(fmt.Sprintf("Target %s is a mount point and already mounted to source %s. Skipping FormatAndMount without any checks", target, source))
+		log.Trace("the target is already mounted to the source, skipping format and mount")
 		return nil
 	}
 
-	s.Log.Trace("-----------------== start FormatAndMount ==---------------")
-
 	if lvmType == internal.LVMTypeThin {
-		s.Log.Trace(fmt.Sprintf("LVM type is Thin. Thin pool name: %s", lvmThinPoolName))
+		log.Trace("thin volume", "thinPoolName", lvmThinPoolName)
 	}
 	err = s.NodeStorage.FormatAndMountSensitiveWithFormatOptions(source, target, fsType, mountOpts, nil, formatOpts)
 	if err != nil {
 		return fmt.Errorf("failed to FormatAndMount : %w", err)
 	}
-	s.Log.Trace("-----------------== stop FormatAndMount ==---------------")
 
-	s.Log.Trace("-----------------== stop NodeStageVolumeFS ==---------------")
 	return nil
 }
 
 func (s *Store) NodePublishVolumeBlock(source, target string, mountOpts []string) error {
-	s.Log.Info(" ----== Start NodePublishVolumeBlock ==---- ")
+	log := s.Log.Named("NodePublishVolumeBlock").With("source", source, "target", target)
 
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ Mount options ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
-	s.Log.Trace(fmt.Sprintf("[NodePublishVolumeBlock] params source=%s target=%s mountOptions=%v", source, target, mountOpts))
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ Mount options ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
+	log.Trace("mount parameters", "mountOptions", mountOpts)
 
 	info, err := os.Stat(source)
 	if err != nil {
@@ -153,11 +136,8 @@ func (s *Store) NodePublishVolumeBlock(source, target string, mountOpts []string
 		return fmt.Errorf("[NodePublishVolumeBlock] path %s is not a device", source)
 	}
 
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ MODE SOURCE ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
-	s.Log.Trace(info.Mode().String())
-	s.Log.Trace("≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈ MODE SOURCE  ≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈≈")
+	log.Trace("source mode", "mode", info.Mode().String())
 
-	s.Log.Trace("-----------------== start Create File ==---------------")
 	f, err := os.OpenFile(target, os.O_CREATE, os.FileMode(0644))
 	if err != nil {
 		if !os.IsExist(err) {
@@ -166,21 +146,17 @@ func (s *Store) NodePublishVolumeBlock(source, target string, mountOpts []string
 	} else {
 		_ = f.Close()
 	}
-	s.Log.Trace("-----------------== stop Create File ==---------------")
-	s.Log.Trace("-----------------== start Mount ==---------------")
 	err = s.NodeStorage.Mount(source, target, "", mountOpts)
 	if err != nil {
-		s.Log.Error(err, "[NodePublishVolumeBlock] mount error :")
+		log.Error("unable to mount the block device", logger.Err(err))
 		return err
 	}
-	s.Log.Trace("-----------------== stop Mount ==---------------")
-	s.Log.Trace("-----------------== stop NodePublishVolumeBlock ==---------------")
 	return nil
 }
 
 func (s *Store) NodePublishVolumeFS(source, devPath, target, fsType string, mountOpts []string) error {
-	s.Log.Info(" ----== Start NodePublishVolumeFS ==---- ")
-	s.Log.Trace(fmt.Sprintf("[NodePublishVolumeFS] params source=%q target=%q mountOptions=%v", source, target, mountOpts))
+	log := s.Log.Named("NodePublishVolumeFS").With("source", source, "target", target)
+	log.Trace("mount parameters", "mountOptions", mountOpts)
 	isMountPoint := false
 	exists, err := s.PathExists(target)
 	if err != nil {
@@ -188,25 +164,25 @@ func (s *Store) NodePublishVolumeFS(source, devPath, target, fsType string, moun
 	}
 
 	if exists {
-		s.Log.Trace(fmt.Sprintf("[NodePublishVolumeFS] target file %s already exists", target))
+		log.Trace("the target file already exists")
 		isMountPoint, err = s.NodeStorage.IsMountPoint(target)
 		if err != nil {
 			return fmt.Errorf("[NodePublishVolumeFS] could not check if target file %s is a mount point: %w", target, err)
 		}
 	} else {
-		s.Log.Trace(fmt.Sprintf("[NodePublishVolumeFS] creating target file %q", target))
+		log.Trace("creating the target file")
 		if err := os.MkdirAll(target, os.FileMode(0755)); err != nil {
 			return fmt.Errorf("[NodePublishVolumeFS] could not create target file %q: %w", target, err)
 		}
 	}
 
 	if isMountPoint {
-		s.Log.Trace(fmt.Sprintf("[NodePublishVolumeFS] target directory %q is a mount point. Check mount", target))
+		log.Trace("the target directory is a mount point, checking the mount")
 		err := checkMount(s, devPath, target, mountOpts)
 		if err != nil {
 			return fmt.Errorf("[NodePublishVolumeFS] failed to check mount info for %q: %w", target, err)
 		}
-		s.Log.Trace(fmt.Sprintf("[NodePublishVolumeFS] target directory %q is a mount point and already mounted to source %s. Skipping mount", target, source))
+		log.Trace("the target directory is already mounted to the source, skipping mount")
 		return nil
 	}
 
@@ -215,7 +191,6 @@ func (s *Store) NodePublishVolumeFS(source, devPath, target, fsType string, moun
 		return fmt.Errorf("[NodePublishVolumeFS] failed to bind mount %q to %q with mount options %v: %w", source, target, mountOpts, err)
 	}
 
-	s.Log.Trace("-----------------== stop NodePublishVolumeFS ==---------------")
 	return nil
 }
 
@@ -224,7 +199,7 @@ func (s *Store) Unpublish(target string) error {
 }
 
 func (s *Store) Unstage(target string) error {
-	s.Log.Info(fmt.Sprintf("[unmount volume] target=%s", target))
+	s.Log.Named("Unstage").Info("unmounting", "target", target)
 	err := mountutils.CleanupMountPoint(target, s.NodeStorage.Interface, false)
 	// Ignore the error when it contains "not mounted", because that indicates the
 	// world is already in the desired state
@@ -250,22 +225,22 @@ func (s *Store) IsNotMountPoint(target string) (bool, error) {
 }
 
 func (s *Store) ResizeFS(mountTarget string) error {
-	s.Log.Info(" ----== Resize FS ==---- ")
+	log := s.Log.Named("ResizeFS").With("mountTarget", mountTarget)
 	devicePath, _, err := mountutils.GetDeviceNameFromMount(s.NodeStorage.Interface, mountTarget)
 	if err != nil {
-		s.Log.Error(err, "Failed to find the device mounted at mountTarget", "mountTarget", mountTarget)
+		log.Error("unable to find the device mounted at the target", logger.Err(err))
 		return fmt.Errorf("failed to find the device mounted at %s: %w", mountTarget, err)
 	}
 
-	s.Log.Info("Found device for resizing", "devicePath", devicePath, "mountTarget", mountTarget)
+	log.Info("found the device to resize", "devicePath", devicePath)
 
 	_, err = mountutils.NewResizeFs(s.NodeStorage.Exec).Resize(devicePath, mountTarget)
 	if err != nil {
-		s.Log.Error(err, "Failed to resize filesystem", "devicePath", devicePath, "mountTarget", mountTarget)
+		log.Error("unable to resize the filesystem", logger.Err(err), slog.String("devicePath", devicePath))
 		return fmt.Errorf("failed to resize filesystem %s on device %s: %w", mountTarget, devicePath, err)
 	}
 
-	s.Log.Info("Filesystem resized successfully", "devicePath", devicePath)
+	log.Info("filesystem resized successfully", "devicePath", devicePath)
 	return nil
 }
 
@@ -300,15 +275,15 @@ func checkMount(s *Store, devPath, target string, mountOpts []string) error {
 			if m.Device != devPath && m.Device != mapperDevicePath {
 				return fmt.Errorf("[checkMount] device from mount point %q does not match expected source device path %s or mapper device path %s", m.Device, devPath, mapperDevicePath)
 			}
-			s.Log.Trace(fmt.Sprintf("[checkMount] mount point %s is mounted to device %s", target, m.Device))
+			s.Log.Trace("the mount point is mounted to a device", "target", target, "device", m.Device)
 
 			if slices.Contains(mountOpts, "ro") {
 				if !slices.Contains(m.Opts, "ro") {
 					return fmt.Errorf("[checkMount] passed mount options contain 'ro' but mount options from mount point %q do not", target)
 				}
-				s.Log.Trace(fmt.Sprintf("[checkMount] mount point %s is mounted read-only", target))
+				s.Log.Trace("the mount point is mounted read-only", "target", target)
 			}
-			s.Log.Trace(fmt.Sprintf("[checkMount] mount point %s is mounted to device %s with mount options %v", target, m.Device, m.Opts))
+			s.Log.Trace("the mount point is mounted to a device", "target", target, "device", m.Device, "mountOptions", m.Opts)
 
 			return nil
 		}

--- a/images/webhooks/cmd/main.go
+++ b/images/webhooks/cmd/main.go
@@ -98,19 +98,19 @@ func main() {
 
 	podSchedulerMutatingWebHookHandler, err := handlers.GetMutatingWebhookHandler(handlers.PodSchedulerMutate, PodSchedulerMutatorID, &corev1.Pod{}, kwhLogger)
 	if err != nil {
-		log.Error(err, "unable to create the pod scheduler mutating webhook handler")
+		log.Error("unable to create the pod scheduler mutating webhook handler", logger.Err(err))
 		os.Exit(1)
 	}
 
 	lscValidatingWebhookHandler, err := handlers.GetValidatingWebhookHandler(handlers.LSCValidate(log), LSCValidatorID, &slv.LocalStorageClass{}, kwhLogger)
 	if err != nil {
-		log.Error(err, "unable to create the LocalStorageClass validating webhook handler")
+		log.Error("unable to create the LocalStorageClass validating webhook handler", logger.Err(err))
 		os.Exit(1)
 	}
 
 	scValidatingWebhookHandler, err := handlers.GetValidatingWebhookHandler(handlers.SCValidate(log), SCValidatorID, &storagev1.StorageClass{}, kwhLogger)
 	if err != nil {
-		log.Error(err, "unable to create the StorageClass validating webhook handler")
+		log.Error("unable to create the StorageClass validating webhook handler", logger.Err(err))
 		os.Exit(1)
 	}
 
@@ -120,9 +120,9 @@ func main() {
 	mux.Handle("/sc-validate", scValidatingWebhookHandler)
 	mux.HandleFunc("/healthz", httpHandlerHealthz)
 
-	log.Info(fmt.Sprintf("listening on %s", port))
+	log.Info("listening", "port", port)
 	if err = http.ListenAndServeTLS(port, cfg.certFile, cfg.keyFile, mux); err != nil {
-		log.Error(err, "unable to serve the webhook")
+		log.Error("unable to serve the webhook", logger.Err(err))
 		os.Exit(1)
 	}
 }

--- a/images/webhooks/cmd/main.go
+++ b/images/webhooks/cmd/main.go
@@ -22,18 +22,18 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/sirupsen/logrus"
-	kwhlogrus "github.com/slok/kubewebhook/v2/pkg/log/logrus"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
 	"github.com/deckhouse/sds-local-volume/images/webhooks/handlers"
+	"github.com/deckhouse/sds-local-volume/images/webhooks/pkg/logger"
 )
 
 type config struct {
 	certFile string
 	keyFile  string
+	logLevel logger.Verbosity
 }
 
 //goland:noinspection SpellCheckingInspection
@@ -47,14 +47,27 @@ func httpHandlerHealthz(w http.ResponseWriter, _ *http.Request) {
 func initFlags() (config, error) {
 	cfg := config{}
 
+	// The level arrives as a flag rather than as LOG_LEVEL, because lib-helm's
+	// helm_lib_module_controller_manifests injects no env into the webhooks
+	// container but does allow its command to be overridden. The accepted values
+	// are the same numeric 0..4 verbosities the other components take.
+	var logLevel string
+
 	fl := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fl.StringVar(&cfg.certFile, "tls-cert-file", "", "TLS certificate file")
 	fl.StringVar(&cfg.keyFile, "tls-key-file", "", "TLS key file")
+	fl.StringVar(&logLevel, "log-level", string(logger.InfoLevel), "Log verbosity: 0 error, 1 warn, 2 info, 3 debug, 4 trace")
 
 	err := fl.Parse(os.Args[1:])
 	if err != nil {
 		return cfg, err
 	}
+
+	cfg.logLevel = logger.Verbosity(logLevel)
+	if _, err := cfg.logLevel.Level(); err != nil {
+		return cfg, err
+	}
+
 	return cfg, nil
 }
 
@@ -66,31 +79,38 @@ const (
 )
 
 func main() {
-	logrusLogEntry := logrus.NewEntry(logrus.New())
-	logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
-	logger := kwhlogrus.NewLogrus(logrusLogEntry)
-
 	cfg, err := initFlags()
 	if err != nil {
 		fmt.Printf("unable to parse config: err: %s", err.Error())
 		os.Exit(1)
 	}
 
-	podSchedulerMutatingWebHookHandler, err := handlers.GetMutatingWebhookHandler(handlers.PodSchedulerMutate, PodSchedulerMutatorID, &corev1.Pod{}, logger)
+	baseLog, err := logger.NewLogger(cfg.logLevel)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error creating podSchedulerMutatingWebHookHandler: %s", err)
+		fmt.Printf("unable to create NewLogger, err: %v\n", err)
+		os.Exit(1)
+	}
+	log := baseLog.Named("webhooks")
+
+	// kubewebhook takes its own logger interface; this adapter routes the
+	// library's own messages into the same output and format as ours.
+	kwhLogger := logger.NewKubewebhookLogger(log)
+
+	podSchedulerMutatingWebHookHandler, err := handlers.GetMutatingWebhookHandler(handlers.PodSchedulerMutate, PodSchedulerMutatorID, &corev1.Pod{}, kwhLogger)
+	if err != nil {
+		log.Error(err, "unable to create the pod scheduler mutating webhook handler")
 		os.Exit(1)
 	}
 
-	lscValidatingWebhookHandler, err := handlers.GetValidatingWebhookHandler(handlers.LSCValidate, LSCValidatorID, &slv.LocalStorageClass{}, logger)
+	lscValidatingWebhookHandler, err := handlers.GetValidatingWebhookHandler(handlers.LSCValidate(log), LSCValidatorID, &slv.LocalStorageClass{}, kwhLogger)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error creating lscValidatingWebhookHandler: %s", err)
+		log.Error(err, "unable to create the LocalStorageClass validating webhook handler")
 		os.Exit(1)
 	}
 
-	scValidatingWebhookHandler, err := handlers.GetValidatingWebhookHandler(handlers.SCValidate, SCValidatorID, &storagev1.StorageClass{}, logger)
+	scValidatingWebhookHandler, err := handlers.GetValidatingWebhookHandler(handlers.SCValidate(log), SCValidatorID, &storagev1.StorageClass{}, kwhLogger)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error creating scValidatingWebhookHandler: %s", err)
+		log.Error(err, "unable to create the StorageClass validating webhook handler")
 		os.Exit(1)
 	}
 
@@ -100,10 +120,9 @@ func main() {
 	mux.Handle("/sc-validate", scValidatingWebhookHandler)
 	mux.HandleFunc("/healthz", httpHandlerHealthz)
 
-	logger.Infof("Listening on %s", port)
-	err = http.ListenAndServeTLS(port, cfg.certFile, cfg.keyFile, mux)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error serving webhook: %s", err)
+	log.Info(fmt.Sprintf("listening on %s", port))
+	if err = http.ListenAndServeTLS(port, cfg.certFile, cfg.keyFile, mux); err != nil {
+		log.Error(err, "unable to serve the webhook")
 		os.Exit(1)
 	}
 }

--- a/images/webhooks/go.mod
+++ b/images/webhooks/go.mod
@@ -2,25 +2,26 @@ module github.com/deckhouse/sds-local-volume/images/webhooks
 
 go 1.26.5
 require (
+	github.com/deckhouse/deckhouse/pkg/log v0.2.1
 	github.com/deckhouse/sds-common-lib v0.5.0
 	github.com/deckhouse/sds-local-volume/api v0.0.0-20250114155747-5d75d401a787
 	github.com/deckhouse/sds-node-configurator/api v0.0.0-20260318114210-2fdda7b75905
-	github.com/sirupsen/logrus v1.9.3
+	github.com/go-logr/logr v1.4.2
 	github.com/slok/kubewebhook/v2 v2.6.0
+	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
-	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.20.4
 )
 
 require (
+	github.com/DataDog/gostackparse v0.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -35,6 +36,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.56.0 // indirect
@@ -48,6 +50,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect

--- a/images/webhooks/go.sum
+++ b/images/webhooks/go.sum
@@ -1,7 +1,11 @@
+github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
+github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckhouse/deckhouse/pkg/log v0.2.1 h1:7SSD+QJPnziAO3l8ycgRwN5wlQeC312Tf7f2Wa/hWDg=
+github.com/deckhouse/deckhouse/pkg/log v0.2.1/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
 github.com/deckhouse/sds-common-lib v0.5.0 h1:dDERy3iKz4UsP2dLFCmoJivaAlUX4+gpdqsQ5l2XnD4=
 github.com/deckhouse/sds-common-lib v0.5.0/go.mod h1:tAZI7ZaVeJi5/Fe5Mebw3d6NC4nTHUOOTwZFnHHzxFU=
 github.com/deckhouse/sds-node-configurator/api v0.0.0-20260318114210-2fdda7b75905 h1:OKwOW3JFlbMxG8lLM9rfLxl+2M8lFpThQRFAJy4lBMQ=
@@ -67,8 +71,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slok/kubewebhook/v2 v2.6.0 h1:NMDDXx219OcNDc17ZYpqGXW81/jkBNmkdEwFDcZDVcA=
 github.com/slok/kubewebhook/v2 v2.6.0/go.mod h1:EoPfBo8lzgU1lmI1DSY/Fpwu+cdr4lZnzY4Tmg5sHe0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
@@ -91,7 +93,6 @@ go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -108,7 +109,6 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=

--- a/images/webhooks/handlers/lscValidator.go
+++ b/images/webhooks/handlers/lscValidator.go
@@ -24,114 +24,125 @@ import (
 	"github.com/slok/kubewebhook/v2/pkg/model"
 	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 
 	slv "github.com/deckhouse/sds-local-volume/api/v1alpha1"
+	"github.com/deckhouse/sds-local-volume/images/webhooks/pkg/logger"
 	snc "github.com/deckhouse/sds-node-configurator/api/v1alpha1"
 )
 
-func LSCValidate(ctx context.Context, _ *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
-	lsc, ok := obj.(*slv.LocalStorageClass)
-	if !ok {
-		// If not a storage class just continue the validation chain(if there is one) and do nothing.
-		return &kwhvalidating.ValidatorResult{}, nil
-	}
+// LSCValidate returns the LocalStorageClass validator, bound to log.
+func LSCValidate(log logger.Logger) kwhvalidating.ValidatorFunc {
+	log = log.Named("lsc-validator")
 
-	cl, err := NewKubeClient("")
-	if err != nil {
-		klog.Fatal(err)
-	}
-
-	if lsc.Spec.LVM == nil {
-		errMsg := fmt.Sprintf("LocalStorageClass %s has no spec.lvm configured", lsc.Name)
-		klog.Info(errMsg)
-		return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
-	}
-
-	if len(lsc.Spec.LVM.LVMVolumeGroups) == 0 {
-		errMsg := "Field spec.lvm.lvmVolumeGroups must not be empty"
-		klog.Info(errMsg)
-		return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
-	}
-
-	listDevice := &snc.LVMVolumeGroupList{}
-
-	err = cl.List(ctx, listDevice)
-	if err != nil {
-		klog.Fatal(err)
-	}
-
-	nameEntries, selectorEntries := 0, 0
-	for _, lvmGroup := range lsc.Spec.LVM.LVMVolumeGroups {
-		if lvmGroup.Name != "" {
-			nameEntries++
+	return func(ctx context.Context, _ *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
+		lsc, ok := obj.(*slv.LocalStorageClass)
+		if !ok {
+			// If not a storage class just continue the validation chain(if there is one) and do nothing.
+			return &kwhvalidating.ValidatorResult{}, nil
 		}
-		if lvmGroup.LabelSelector != nil {
-			selectorEntries++
+
+		cl, err := NewKubeClient("")
+		if err != nil {
+			// Returning the error fails this one admission request. The previous
+			// klog.Fatal exited the process, so a single transient failure here
+			// took the webhook down for every request until the pod restarted.
+			log.Error(err, "unable to build a kube client")
+			return nil, err
 		}
-	}
-	if nameEntries > 0 && selectorEntries > 0 {
-		errMsg := "spec.lvm.lvmVolumeGroups must use either name entries or labelSelector entries, not a mix"
-		klog.Info(errMsg)
-		return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
-	}
 
-	var lvmVolumeGroupUnique []string
-
-	for i, lvmGroup := range lsc.Spec.LVM.LVMVolumeGroups {
-		hasName := lvmGroup.Name != ""
-		hasSelector := lvmGroup.LabelSelector != nil
-
-		if hasName == hasSelector {
-			errMsg := fmt.Sprintf("Each spec.lvm.lvmVolumeGroups entry must set exactly one of name or labelSelector (entry #%d)", i)
-			klog.Info(errMsg)
+		if lsc.Spec.LVM == nil {
+			errMsg := fmt.Sprintf("LocalStorageClass %s has no spec.lvm configured", lsc.Name)
+			log.Info(errMsg)
 			return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
 		}
 
-		if lsc.Spec.LVM.Type == "Thin" {
-			if lvmGroup.Thin == nil || lvmGroup.Thin.PoolName == "" {
-				errMsg := fmt.Sprintf("Field thin.poolName is required for spec.lvm.lvmVolumeGroups entry #%d when type is Thin", i)
-				klog.Info(errMsg)
+		if len(lsc.Spec.LVM.LVMVolumeGroups) == 0 {
+			errMsg := "Field spec.lvm.lvmVolumeGroups must not be empty"
+			log.Info(errMsg)
+			return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
+		}
+
+		listDevice := &snc.LVMVolumeGroupList{}
+
+		err = cl.List(ctx, listDevice)
+		if err != nil {
+			// As above: fail the request, do not exit the process.
+			log.Error(err, "unable to list LVMVolumeGroups")
+			return nil, err
+		}
+
+		nameEntries, selectorEntries := 0, 0
+		for _, lvmGroup := range lsc.Spec.LVM.LVMVolumeGroups {
+			if lvmGroup.Name != "" {
+				nameEntries++
+			}
+			if lvmGroup.LabelSelector != nil {
+				selectorEntries++
+			}
+		}
+		if nameEntries > 0 && selectorEntries > 0 {
+			errMsg := "spec.lvm.lvmVolumeGroups must use either name entries or labelSelector entries, not a mix"
+			log.Info(errMsg)
+			return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
+		}
+
+		var lvmVolumeGroupUnique []string
+
+		for i, lvmGroup := range lsc.Spec.LVM.LVMVolumeGroups {
+			hasName := lvmGroup.Name != ""
+			hasSelector := lvmGroup.LabelSelector != nil
+
+			if hasName == hasSelector {
+				errMsg := fmt.Sprintf("Each spec.lvm.lvmVolumeGroups entry must set exactly one of name or labelSelector (entry #%d)", i)
+				log.Info(errMsg)
 				return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
 			}
-		} else if lvmGroup.Thin != nil {
-			errMsg := fmt.Sprintf("Field thin must not be specified for spec.lvm.lvmVolumeGroups entry #%d when type is Thick", i)
-			klog.Info(errMsg)
-			return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
-		}
 
-		if hasSelector {
-			if _, err := metav1.LabelSelectorAsSelector(lvmGroup.LabelSelector); err != nil {
-				errMsg := fmt.Sprintf("Invalid labelSelector in spec.lvm.lvmVolumeGroups entry #%d: %s", i, err.Error())
-				klog.Info(errMsg)
+			if lsc.Spec.LVM.Type == "Thin" {
+				if lvmGroup.Thin == nil || lvmGroup.Thin.PoolName == "" {
+					errMsg := fmt.Sprintf("Field thin.poolName is required for spec.lvm.lvmVolumeGroups entry #%d when type is Thin", i)
+					log.Info(errMsg)
+					return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
+				}
+			} else if lvmGroup.Thin != nil {
+				errMsg := fmt.Sprintf("Field thin must not be specified for spec.lvm.lvmVolumeGroups entry #%d when type is Thick", i)
+				log.Info(errMsg)
 				return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
 			}
-			// The concrete match set (existence, emptiness, same-node conflicts)
-			// is validated by the controller, which reflects the result in the
-			// LocalStorageClass status.
-			continue
-		}
 
-		if slices.Contains(lvmVolumeGroupUnique, lvmGroup.Name) {
-			errMsg := fmt.Sprintf("There must be unique LVMVolumeGroup names (%s duplicates)", lvmGroup.Name)
-			klog.Info(errMsg)
-			return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
-		}
-		lvmVolumeGroupUnique = append(lvmVolumeGroupUnique, lvmGroup.Name)
+			if hasSelector {
+				if _, err := metav1.LabelSelectorAsSelector(lvmGroup.LabelSelector); err != nil {
+					errMsg := fmt.Sprintf("Invalid labelSelector in spec.lvm.lvmVolumeGroups entry #%d: %s", i, err.Error())
+					log.Info(errMsg)
+					return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
+				}
+				// The concrete match set (existence, emptiness, same-node conflicts)
+				// is validated by the controller, which reflects the result in the
+				// LocalStorageClass status.
+				continue
+			}
 
-		lvgExists := false
-		for _, lvmVG := range listDevice.Items {
-			if lvmVG.Name == lvmGroup.Name {
-				lvgExists = true
-				break
+			if slices.Contains(lvmVolumeGroupUnique, lvmGroup.Name) {
+				errMsg := fmt.Sprintf("There must be unique LVMVolumeGroup names (%s duplicates)", lvmGroup.Name)
+				log.Info(errMsg)
+				return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
+			}
+			lvmVolumeGroupUnique = append(lvmVolumeGroupUnique, lvmGroup.Name)
+
+			lvgExists := false
+			for _, lvmVG := range listDevice.Items {
+				if lvmVG.Name == lvmGroup.Name {
+					lvgExists = true
+					break
+				}
+			}
+			if !lvgExists {
+				errMsg := fmt.Sprintf("LVMVolumeGroup %s not found; ", lvmGroup.Name)
+				log.Info(errMsg)
+				return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
 			}
 		}
-		if !lvgExists {
-			errMsg := fmt.Sprintf("LVMVolumeGroup %s not found; ", lvmGroup.Name)
-			klog.Info(errMsg)
-			return &kwhvalidating.ValidatorResult{Valid: false, Message: errMsg}, nil
-		}
-	}
 
-	return &kwhvalidating.ValidatorResult{Valid: true}, nil
+		return &kwhvalidating.ValidatorResult{Valid: true}, nil
+	}
 }

--- a/images/webhooks/handlers/lscValidator.go
+++ b/images/webhooks/handlers/lscValidator.go
@@ -46,7 +46,7 @@ func LSCValidate(log logger.Logger) kwhvalidating.ValidatorFunc {
 			// Returning the error fails this one admission request. The previous
 			// klog.Fatal exited the process, so a single transient failure here
 			// took the webhook down for every request until the pod restarted.
-			log.Error(err, "unable to build a kube client")
+			log.Error("unable to build a kube client", logger.Err(err))
 			return nil, err
 		}
 
@@ -67,7 +67,7 @@ func LSCValidate(log logger.Logger) kwhvalidating.ValidatorFunc {
 		err = cl.List(ctx, listDevice)
 		if err != nil {
 			// As above: fail the request, do not exit the process.
-			log.Error(err, "unable to list LVMVolumeGroups")
+			log.Error("unable to list LVMVolumeGroups", logger.Err(err))
 			return nil, err
 		}
 

--- a/images/webhooks/handlers/scValidator.go
+++ b/images/webhooks/handlers/scValidator.go
@@ -48,7 +48,7 @@ func SCValidate(log logger.Logger) kwhvalidating.ValidatorFunc {
 
 		if sc.Provisioner == localCSIProvisioner {
 			if arReview.UserInfo.Username == allowedUserName {
-				log.Info(fmt.Sprintf("User %s is allowed to manage storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner))
+				log.Info("the user is allowed to manage StorageClasses of this provisioner", "user", arReview.UserInfo.Username, "provisioner", localCSIProvisioner)
 				return &kwhvalidating.ValidatorResult{Valid: true}, nil
 			}
 			if arReview.Operation == model.OperationUpdate {
@@ -58,12 +58,12 @@ func SCValidate(log logger.Logger) kwhvalidating.ValidatorFunc {
 				}
 
 				if !changed {
-					log.Info(fmt.Sprintf("User %s is allowed to change annotations for storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner))
+					log.Info("the user is allowed to change annotations of StorageClasses of this provisioner", "user", arReview.UserInfo.Username, "provisioner", localCSIProvisioner)
 					return &kwhvalidating.ValidatorResult{Valid: true}, nil
 				}
 			}
 
-			log.Info(fmt.Sprintf("User %s is not allowed to manage storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner))
+			log.Info("the user is not allowed to manage StorageClasses of this provisioner", "user", arReview.UserInfo.Username, "provisioner", localCSIProvisioner)
 			return &kwhvalidating.ValidatorResult{
 				Valid:   false,
 				Message: fmt.Sprintf("Direct modifications to the StorageClass (other than annotations) with the provisioner %s are not allowed. Please use LocalStorageClass for such operations.", localCSIProvisioner),
@@ -88,43 +88,43 @@ func isStorageClassChangedExceptAnnotations(log logger.Logger, oldObjectRaw, new
 	}
 
 	log.Info("=====================================")
-	log.Info(fmt.Sprintf("Comparing old object: %+v", oldSC))
+	log.Debug("comparing the StorageClass revisions", "old", fmt.Sprintf("%+v", oldSC), "new", fmt.Sprintf("%+v", newSC))
 	log.Info("=====================================")
-	log.Info(fmt.Sprintf("Comparing new object: %+v", newSC))
+
 	log.Info("=====================================")
 
 	if oldSC.Provisioner != newSC.Provisioner {
-		log.Info(fmt.Sprintf("Provisioner changed from %s to %s", oldSC.Provisioner, newSC.Provisioner))
+		log.Info("the provisioner changed", "field", "provisioner", "old", oldSC.Provisioner, "new", newSC.Provisioner)
 		return true, nil
 	}
 
 	if *oldSC.VolumeBindingMode != *newSC.VolumeBindingMode {
-		log.Info(fmt.Sprintf("VolumeBindingMode changed from %s to %s", *oldSC.VolumeBindingMode, *newSC.VolumeBindingMode))
+		log.Info("the volume binding mode changed", "field", "volumeBindingMode", "old", *oldSC.VolumeBindingMode, "new", *newSC.VolumeBindingMode)
 		return true, nil
 	}
 
 	if *oldSC.ReclaimPolicy != *newSC.ReclaimPolicy {
-		log.Info(fmt.Sprintf("ReclaimPolicy changed from %s to %s", *oldSC.ReclaimPolicy, *newSC.ReclaimPolicy))
+		log.Info("the reclaim policy changed", "field", "reclaimPolicy", "old", *oldSC.ReclaimPolicy, "new", *newSC.ReclaimPolicy)
 		return true, nil
 	}
 
 	if !reflect.DeepEqual(oldSC.Parameters, newSC.Parameters) {
-		log.Info(fmt.Sprintf("Parameters changed from %v to %v", oldSC.Parameters, newSC.Parameters))
+		log.Info("the parameters changed", "field", "parameters", "old", fmt.Sprintf("%v", oldSC.Parameters), "new", fmt.Sprintf("%v", newSC.Parameters))
 		return true, nil
 	}
 
 	if *oldSC.AllowVolumeExpansion != *newSC.AllowVolumeExpansion {
-		log.Info(fmt.Sprintf("AllowVolumeExpansion changed from %v to %v", *oldSC.AllowVolumeExpansion, *newSC.AllowVolumeExpansion))
+		log.Info("allowVolumeExpansion changed", "field", "allowVolumeExpansion", "old", *oldSC.AllowVolumeExpansion, "new", *newSC.AllowVolumeExpansion)
 		return true, nil
 	}
 
 	if !reflect.DeepEqual(oldSC.MountOptions, newSC.MountOptions) {
-		log.Info(fmt.Sprintf("MountOptions changed from %v to %v", oldSC.MountOptions, newSC.MountOptions))
+		log.Info("the mount options changed", "field", "mountOptions", "old", fmt.Sprintf("%v", oldSC.MountOptions), "new", fmt.Sprintf("%v", newSC.MountOptions))
 		return true, nil
 	}
 
 	if !reflect.DeepEqual(oldSC.AllowedTopologies, newSC.AllowedTopologies) {
-		log.Info(fmt.Sprintf("AllowedTopologies changed from %v to %v", oldSC.AllowedTopologies, newSC.AllowedTopologies))
+		log.Info("the allowed topologies changed", "field", "allowedTopologies", "old", fmt.Sprintf("%v", oldSC.AllowedTopologies), "new", fmt.Sprintf("%v", newSC.AllowedTopologies))
 		return true, nil
 	}
 
@@ -135,7 +135,7 @@ func isStorageClassChangedExceptAnnotations(log logger.Logger, oldObjectRaw, new
 	oldSC.ManagedFields = nil
 
 	if !reflect.DeepEqual(oldSC.ObjectMeta, newSC.ObjectMeta) {
-		log.Info(fmt.Sprintf("ObjectMeta changed from %+v to %+v", oldSC.ObjectMeta, newSC.ObjectMeta))
+		log.Info("the object metadata changed", "field", "objectMeta", "old", fmt.Sprintf("%+v", oldSC.ObjectMeta), "new", fmt.Sprintf("%+v", newSC.ObjectMeta))
 		return true, nil
 	}
 

--- a/images/webhooks/handlers/scValidator.go
+++ b/images/webhooks/handlers/scValidator.go
@@ -26,7 +26,8 @@ import (
 	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+
+	"github.com/deckhouse/sds-local-volume/images/webhooks/pkg/logger"
 )
 
 const (
@@ -34,41 +35,46 @@ const (
 	allowedUserName     = "system:serviceaccount:d8-sds-local-volume:controller"
 )
 
-func SCValidate(_ context.Context, arReview *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
-	sc, ok := obj.(*storagev1.StorageClass)
-	if !ok {
-		// If not a storage class just continue the validation chain(if there is one) and do nothing.
-		return &kwhvalidating.ValidatorResult{}, nil
-	}
+// SCValidate returns the StorageClass validator, bound to log.
+func SCValidate(log logger.Logger) kwhvalidating.ValidatorFunc {
+	log = log.Named("sc-validator")
 
-	if sc.Provisioner == localCSIProvisioner {
-		if arReview.UserInfo.Username == allowedUserName {
-			klog.Infof("User %s is allowed to manage storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner)
-			return &kwhvalidating.ValidatorResult{Valid: true}, nil
+	return func(_ context.Context, arReview *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
+		sc, ok := obj.(*storagev1.StorageClass)
+		if !ok {
+			// If not a storage class just continue the validation chain(if there is one) and do nothing.
+			return &kwhvalidating.ValidatorResult{}, nil
 		}
-		if arReview.Operation == model.OperationUpdate {
-			changed, err := isStorageClassChangedExceptAnnotations(arReview.OldObjectRaw, arReview.NewObjectRaw)
-			if err != nil {
-				return nil, err
-			}
 
-			if !changed {
-				klog.Infof("User %s is allowed to change annotations for storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner)
+		if sc.Provisioner == localCSIProvisioner {
+			if arReview.UserInfo.Username == allowedUserName {
+				log.Info(fmt.Sprintf("User %s is allowed to manage storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner))
 				return &kwhvalidating.ValidatorResult{Valid: true}, nil
 			}
+			if arReview.Operation == model.OperationUpdate {
+				changed, err := isStorageClassChangedExceptAnnotations(log, arReview.OldObjectRaw, arReview.NewObjectRaw)
+				if err != nil {
+					return nil, err
+				}
+
+				if !changed {
+					log.Info(fmt.Sprintf("User %s is allowed to change annotations for storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner))
+					return &kwhvalidating.ValidatorResult{Valid: true}, nil
+				}
+			}
+
+			log.Info(fmt.Sprintf("User %s is not allowed to manage storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner))
+			return &kwhvalidating.ValidatorResult{
+				Valid:   false,
+				Message: fmt.Sprintf("Direct modifications to the StorageClass (other than annotations) with the provisioner %s are not allowed. Please use LocalStorageClass for such operations.", localCSIProvisioner),
+			}, nil
 		}
 
-		klog.Infof("User %s is not allowed to manage storage classes with provisioner %s", arReview.UserInfo.Username, localCSIProvisioner)
-		return &kwhvalidating.ValidatorResult{
-			Valid:   false,
-			Message: fmt.Sprintf("Direct modifications to the StorageClass (other than annotations) with the provisioner %s are not allowed. Please use LocalStorageClass for such operations.", localCSIProvisioner),
-		}, nil
+		return &kwhvalidating.ValidatorResult{Valid: true}, nil
 	}
-
-	return &kwhvalidating.ValidatorResult{Valid: true}, nil
 }
 
-func isStorageClassChangedExceptAnnotations(oldObjectRaw, newObjectRaw []byte) (bool, error) {
+func isStorageClassChangedExceptAnnotations(log logger.Logger, oldObjectRaw, newObjectRaw []byte) (bool, error) {
 	var oldSC, newSC storagev1.StorageClass
 
 	if err := json.Unmarshal(oldObjectRaw, &oldSC); err != nil {
@@ -81,44 +87,44 @@ func isStorageClassChangedExceptAnnotations(oldObjectRaw, newObjectRaw []byte) (
 		return false, err
 	}
 
-	klog.Info("=====================================")
-	klog.Infof("Comparing old object: %+v", oldSC)
-	klog.Info("=====================================")
-	klog.Infof("Comparing new object: %+v", newSC)
-	klog.Info("=====================================")
+	log.Info("=====================================")
+	log.Info(fmt.Sprintf("Comparing old object: %+v", oldSC))
+	log.Info("=====================================")
+	log.Info(fmt.Sprintf("Comparing new object: %+v", newSC))
+	log.Info("=====================================")
 
 	if oldSC.Provisioner != newSC.Provisioner {
-		klog.Infof("Provisioner changed from %s to %s", oldSC.Provisioner, newSC.Provisioner)
+		log.Info(fmt.Sprintf("Provisioner changed from %s to %s", oldSC.Provisioner, newSC.Provisioner))
 		return true, nil
 	}
 
 	if *oldSC.VolumeBindingMode != *newSC.VolumeBindingMode {
-		klog.Infof("VolumeBindingMode changed from %s to %s", *oldSC.VolumeBindingMode, *newSC.VolumeBindingMode)
+		log.Info(fmt.Sprintf("VolumeBindingMode changed from %s to %s", *oldSC.VolumeBindingMode, *newSC.VolumeBindingMode))
 		return true, nil
 	}
 
 	if *oldSC.ReclaimPolicy != *newSC.ReclaimPolicy {
-		klog.Infof("ReclaimPolicy changed from %s to %s", *oldSC.ReclaimPolicy, *newSC.ReclaimPolicy)
+		log.Info(fmt.Sprintf("ReclaimPolicy changed from %s to %s", *oldSC.ReclaimPolicy, *newSC.ReclaimPolicy))
 		return true, nil
 	}
 
 	if !reflect.DeepEqual(oldSC.Parameters, newSC.Parameters) {
-		klog.Infof("Parameters changed from %v to %v", oldSC.Parameters, newSC.Parameters)
+		log.Info(fmt.Sprintf("Parameters changed from %v to %v", oldSC.Parameters, newSC.Parameters))
 		return true, nil
 	}
 
 	if *oldSC.AllowVolumeExpansion != *newSC.AllowVolumeExpansion {
-		klog.Infof("AllowVolumeExpansion changed from %v to %v", *oldSC.AllowVolumeExpansion, *newSC.AllowVolumeExpansion)
+		log.Info(fmt.Sprintf("AllowVolumeExpansion changed from %v to %v", *oldSC.AllowVolumeExpansion, *newSC.AllowVolumeExpansion))
 		return true, nil
 	}
 
 	if !reflect.DeepEqual(oldSC.MountOptions, newSC.MountOptions) {
-		klog.Infof("MountOptions changed from %v to %v", oldSC.MountOptions, newSC.MountOptions)
+		log.Info(fmt.Sprintf("MountOptions changed from %v to %v", oldSC.MountOptions, newSC.MountOptions))
 		return true, nil
 	}
 
 	if !reflect.DeepEqual(oldSC.AllowedTopologies, newSC.AllowedTopologies) {
-		klog.Infof("AllowedTopologies changed from %v to %v", oldSC.AllowedTopologies, newSC.AllowedTopologies)
+		log.Info(fmt.Sprintf("AllowedTopologies changed from %v to %v", oldSC.AllowedTopologies, newSC.AllowedTopologies))
 		return true, nil
 	}
 
@@ -129,7 +135,7 @@ func isStorageClassChangedExceptAnnotations(oldObjectRaw, newObjectRaw []byte) (
 	oldSC.ManagedFields = nil
 
 	if !reflect.DeepEqual(oldSC.ObjectMeta, newSC.ObjectMeta) {
-		klog.Infof("ObjectMeta changed from %+v to %+v", oldSC.ObjectMeta, newSC.ObjectMeta)
+		log.Info(fmt.Sprintf("ObjectMeta changed from %+v to %+v", oldSC.ObjectMeta, newSC.ObjectMeta))
 		return true, nil
 	}
 

--- a/images/webhooks/pkg/logger/kubewebhook.go
+++ b/images/webhooks/pkg/logger/kubewebhook.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"context"
+	"fmt"
+
+	kwhlog "github.com/slok/kubewebhook/v2/pkg/log"
+)
+
+// kubewebhookAdapter satisfies kubewebhook's logger interface on top of Logger.
+//
+// kubewebhook ships an adapter for logrus only, which is the sole reason logrus
+// used to be a dependency of this component. Its interface is printf-style, so
+// messages coming from the library arrive pre-formatted; the structured values it
+// passes through WithValues are preserved as fields.
+type kubewebhookAdapter struct {
+	log    Logger
+	values map[string]interface{}
+}
+
+var _ kwhlog.Logger = kubewebhookAdapter{}
+
+// NewKubewebhookLogger adapts log for use as kubewebhook's logger.
+func NewKubewebhookLogger(log Logger) kwhlog.Logger {
+	return kubewebhookAdapter{log: log.Named("kubewebhook")}
+}
+
+func (a kubewebhookAdapter) Infof(format string, args ...interface{}) {
+	a.log.Info(fmt.Sprintf(format, args...), a.fields()...)
+}
+
+func (a kubewebhookAdapter) Warningf(format string, args ...interface{}) {
+	a.log.Warning(fmt.Sprintf(format, args...), a.fields()...)
+}
+
+// Errorf logs at error level. kubewebhook hands over a formatted string rather
+// than an error value, so there is nothing to pass to Logger.Error's error
+// parameter.
+func (a kubewebhookAdapter) Errorf(format string, args ...interface{}) {
+	a.log.Error(nil, fmt.Sprintf(format, args...), a.fields()...)
+}
+
+func (a kubewebhookAdapter) Debugf(format string, args ...interface{}) {
+	a.log.Debug(fmt.Sprintf(format, args...), a.fields()...)
+}
+
+func (a kubewebhookAdapter) WithValues(values map[string]interface{}) kwhlog.Logger {
+	if len(values) == 0 {
+		return a
+	}
+
+	merged := make(map[string]interface{}, len(a.values)+len(values))
+	for k, v := range a.values {
+		merged[k] = v
+	}
+	for k, v := range values {
+		merged[k] = v
+	}
+
+	return kubewebhookAdapter{log: a.log, values: merged}
+}
+
+func (a kubewebhookAdapter) WithCtxValues(ctx context.Context) kwhlog.Logger {
+	return a.WithValues(kwhlog.ValuesFromCtx(ctx))
+}
+
+func (a kubewebhookAdapter) SetValuesOnCtx(parent context.Context, values map[string]interface{}) context.Context {
+	return kwhlog.CtxWithValues(parent, values)
+}
+
+// fields flattens the accumulated values into the key/value form the module
+// logger takes.
+func (a kubewebhookAdapter) fields() []interface{} {
+	if len(a.values) == 0 {
+		return nil
+	}
+
+	out := make([]interface{}, 0, len(a.values)*2)
+	for k, v := range a.values {
+		out = append(out, k, v)
+	}
+	return out
+}

--- a/images/webhooks/pkg/logger/kubewebhook.go
+++ b/images/webhooks/pkg/logger/kubewebhook.go
@@ -46,14 +46,13 @@ func (a kubewebhookAdapter) Infof(format string, args ...interface{}) {
 }
 
 func (a kubewebhookAdapter) Warningf(format string, args ...interface{}) {
-	a.log.Warning(fmt.Sprintf(format, args...), a.fields()...)
+	a.log.Warn(fmt.Sprintf(format, args...), a.fields()...)
 }
 
 // Errorf logs at error level. kubewebhook hands over a formatted string rather
-// than an error value, so there is nothing to pass to Logger.Error's error
-// parameter.
+// than an error value, so no error field is attached.
 func (a kubewebhookAdapter) Errorf(format string, args ...interface{}) {
-	a.log.Error(nil, fmt.Sprintf(format, args...), a.fields()...)
+	a.log.Error(fmt.Sprintf(format, args...), a.fields()...)
 }
 
 func (a kubewebhookAdapter) Debugf(format string, args ...interface{}) {

--- a/images/webhooks/pkg/logger/kubewebhook_test.go
+++ b/images/webhooks/pkg/logger/kubewebhook_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	kwhlog "github.com/slok/kubewebhook/v2/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestKubewebhookLogger(t *testing.T, level Verbosity) (kwhlog.Logger, *strings.Builder) {
+	t.Helper()
+
+	buf := &strings.Builder{}
+	l, err := NewLoggerToWriter(buf, level)
+	require.NoError(t, err)
+	return NewKubewebhookLogger(*l), buf
+}
+
+func TestKubewebhookAdapterFormatsMessages(t *testing.T) {
+	log, buf := newTestKubewebhookLogger(t, TraceLevel)
+
+	log.Infof("webhook %s received %d reviews", "lsc-validation", 3)
+
+	out := buf.String()
+	assert.Contains(t, out, "webhook lsc-validation received 3 reviews")
+	// The library's own records are namespaced, so they can be told apart from
+	// the module's.
+	assert.Contains(t, out, "kubewebhook")
+}
+
+func TestKubewebhookAdapterMapsLevels(t *testing.T) {
+	tests := []struct {
+		name  string
+		emit  func(l kwhlog.Logger)
+		level string
+	}{
+		{name: "Debugf", emit: func(l kwhlog.Logger) { l.Debugf("m") }, level: `"level":"debug"`},
+		{name: "Infof", emit: func(l kwhlog.Logger) { l.Infof("m") }, level: `"level":"info"`},
+		{name: "Warningf", emit: func(l kwhlog.Logger) { l.Warningf("m") }, level: `"level":"warn"`},
+		{name: "Errorf", emit: func(l kwhlog.Logger) { l.Errorf("m") }, level: `"level":"error"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, buf := newTestKubewebhookLogger(t, TraceLevel)
+			tt.emit(log)
+			assert.Contains(t, buf.String(), tt.level)
+		})
+	}
+}
+
+func TestKubewebhookAdapterRespectsLevel(t *testing.T) {
+	log, buf := newTestKubewebhookLogger(t, ErrorLevel)
+
+	// The level used to be hard-coded to Debug in main, so the webhook logged
+	// at debug regardless of the module's logLevel setting.
+	log.Debugf("a-debug")
+	log.Infof("an-info")
+	log.Errorf("an-error")
+
+	out := buf.String()
+	assert.NotContains(t, out, "a-debug")
+	assert.NotContains(t, out, "an-info")
+	assert.Contains(t, out, "an-error")
+}
+
+func TestKubewebhookAdapterWithValues(t *testing.T) {
+	log, buf := newTestKubewebhookLogger(t, TraceLevel)
+
+	log.WithValues(map[string]interface{}{"webhook": "lsc-validation"}).Infof("handled")
+
+	out := buf.String()
+	assert.Contains(t, out, "handled")
+	assert.Contains(t, out, "lsc-validation")
+}
+
+func TestKubewebhookAdapterWithValuesAccumulates(t *testing.T) {
+	log, buf := newTestKubewebhookLogger(t, TraceLevel)
+
+	log.WithValues(map[string]interface{}{"a": "1"}).
+		WithValues(map[string]interface{}{"b": "2"}).
+		Infof("handled")
+
+	out := buf.String()
+	assert.Contains(t, out, `"a":"1"`)
+	assert.Contains(t, out, `"b":"2"`)
+}
+
+func TestKubewebhookAdapterWithValuesDoesNotMutateTheParent(t *testing.T) {
+	log, buf := newTestKubewebhookLogger(t, TraceLevel)
+
+	child := log.WithValues(map[string]interface{}{"only": "child"})
+	child.Infof("from-child")
+	log.Infof("from-parent")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "child")
+	assert.NotContains(t, lines[1], `"only"`)
+}
+
+func TestKubewebhookAdapterCtxValuesRoundTrip(t *testing.T) {
+	log, buf := newTestKubewebhookLogger(t, TraceLevel)
+
+	ctx := log.SetValuesOnCtx(context.Background(), map[string]interface{}{"reviewID": "abc"})
+	log.WithCtxValues(ctx).Infof("handled")
+
+	assert.Contains(t, buf.String(), "abc")
+}

--- a/images/webhooks/pkg/logger/kubewebhook_test.go
+++ b/images/webhooks/pkg/logger/kubewebhook_test.go
@@ -32,7 +32,7 @@ func newTestKubewebhookLogger(t *testing.T, level Verbosity) (kwhlog.Logger, *st
 	buf := &strings.Builder{}
 	l, err := NewLoggerToWriter(buf, level)
 	require.NoError(t, err)
-	return NewKubewebhookLogger(*l), buf
+	return NewKubewebhookLogger(l), buf
 }
 
 func TestKubewebhookAdapterFormatsMessages(t *testing.T) {

--- a/images/webhooks/pkg/logger/logger.go
+++ b/images/webhooks/pkg/logger/logger.go
@@ -17,11 +17,9 @@ limitations under the License.
 // Package logger wraps github.com/deckhouse/deckhouse/pkg/log in the small API
 // this module uses.
 //
-// The method set (Error/Warning/Info/Debug/Trace) is kept from the previous
-// klog-based implementation so that existing call sites are unaffected, and so
-// is the Verbosity type: LOG_LEVEL is delivered as a number 0..4 both by
-// lib-helm's helm_lib_module_controller_log_level and by the module's own CSI
-// templates, and that contract must not change.
+// The method set (Error/Warning/Info/Debug/Trace) and the Verbosity type match
+// the controller and CSI copies of this package, so that all three components of
+// the module log in one format and take the same numeric 0..4 level.
 package logger
 
 import (

--- a/images/webhooks/pkg/logger/logger.go
+++ b/images/webhooks/pkg/logger/logger.go
@@ -14,12 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package logger wraps github.com/deckhouse/deckhouse/pkg/log in the small API
-// this module uses.
+// Package logger adapts github.com/deckhouse/deckhouse/pkg/log to this module.
 //
-// The method set (Error/Warning/Info/Debug/Trace) and the Verbosity type match
-// the controller and CSI copies of this package, so that all three components of
-// the module log in one format and take the same numeric 0..4 level.
+// Logger embeds *log.Logger rather than wrapping it, so Info/Debug/Warn/Error are
+// the library's own methods. That is deliberate: sloglint and govet's slog
+// analyzer only recognise log/slog and types embedding *slog.Logger, so
+// embedding is what puts every call site in the module under those checks. A
+// hand-written forwarding method would hide them again.
+//
+// Only what the library does not provide is added here: Verbosity parsing for the
+// numeric LOG_LEVEL contract, a Trace level, and Named/With overridden to return
+// this type.
+//
+// The numeric 0..4 level is the same one the controller and CSI components take,
+// so all three log identically; webhooks receives it as a -log-level flag.
 package logger
 
 import (
@@ -79,55 +87,53 @@ func (v Verbosity) Level() (log.Level, error) {
 	}
 }
 
+// Logger is the module logger.
+//
+// The embedded pointer is what exposes Info, Debug, Warn and Error directly from
+// the library, and what makes those calls visible to the slog linters. Build one
+// with NewLogger, NewLoggerToWriter or NewNop; the zero value has no embedded
+// logger and panics on use.
 type Logger struct {
-	log *log.Logger
+	*log.Logger
 }
 
-// nop backs the zero Logger. The previous logr-based implementation held a
-// logr.Logger by value, whose zero value discards silently, and callers rely on
-// that: a zero Logger must stay a no-op rather than panic.
-var nop = log.NewNop()
-
-// unwrap returns the underlying logger, substituting the discard logger for a
-// zero Logger.
-func (l Logger) unwrap() *log.Logger {
-	if l.log == nil {
-		return nop
-	}
-	return l.log
-}
+// Err wraps an error into the field the library uses for it. Re-exported so that
+// a call site does not have to import pkg/log next to its own log variable:
+//
+//	log.Error("unable to create the volume", logger.Err(err))
+var Err = log.Err
 
 // NewLogger returns a logger emitting at the given verbosity.
-func NewLogger(level Verbosity) (*Logger, error) {
+func NewLogger(level Verbosity) (Logger, error) {
 	lvl, err := level.Level()
 	if err != nil {
-		return nil, err
+		return Logger{}, err
 	}
 
-	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()))}, nil
+	return Logger{log.NewLogger(log.WithLevel(lvl.Level()))}, nil
 }
 
 // NewLoggerToWriter returns a logger writing to w, for tests that want the
 // output attached to their own reporter.
-func NewLoggerToWriter(w io.Writer, level Verbosity) (*Logger, error) {
+func NewLoggerToWriter(w io.Writer, level Verbosity) (Logger, error) {
 	lvl, err := level.Level()
 	if err != nil {
-		return nil, err
+		return Logger{}, err
 	}
 
-	return &Logger{log: log.NewLogger(log.WithLevel(lvl.Level()), log.WithOutput(w))}, nil
+	return Logger{log.NewLogger(log.WithLevel(lvl.Level()), log.WithOutput(w))}, nil
 }
 
 // NewNop returns a logger that discards everything, for tests that do not care
 // about log output.
-func NewNop() *Logger {
-	return &Logger{log: log.NewNop()}
+func NewNop() Logger {
+	return Logger{log.NewNop()}
 }
 
 // NewLoggerFromSlog adapts an existing pkg/log logger, so that a caller which
 // already built one does not have to reconfigure it.
 func NewLoggerFromSlog(l *log.Logger) Logger {
-	return Logger{log: l}
+	return Logger{l}
 }
 
 // Named appends name to the logger's dotted trace path, e.g. a logger named
@@ -135,92 +141,65 @@ func NewLoggerFromSlog(l *log.Logger) Logger {
 // "local-storage-class-controller.reconcile". Use it instead of hand-writing a
 // "[Component]" prefix into the message.
 func (l Logger) Named(name string) Logger {
-	return Logger{log: l.unwrap().Named(name)}
+	return Logger{l.Logger.Named(name)}
 }
 
 // With returns a logger that attaches the given key/value pairs to every
 // record. Use it for values that are constant for a unit of work, such as a
 // traceID or a volumeID, instead of interpolating them into each message.
 func (l Logger) With(args ...any) Logger {
-	return Logger{log: l.unwrap().With(args...)}
+	return Logger{l.Logger.With(args...)}
 }
 
-// SetLevel changes the emitted level in place, on every logger derived from this
-// one, without recreating it.
-func (l Logger) SetLevel(level Verbosity) error {
+// SetVerbosity changes the emitted level in place, on every logger derived from
+// this one, without recreating it.
+//
+// Named SetVerbosity rather than SetLevel so that it does not shadow the embedded
+// SetLevel, which takes a log.Level instead of the numeric Verbosity.
+func (l Logger) SetVerbosity(level Verbosity) error {
 	lvl, err := level.Level()
 	if err != nil {
 		return err
 	}
 
-	l.unwrap().SetLevel(lvl)
+	l.SetLevel(lvl)
 	return nil
 }
 
 // GetSlogLogger returns the underlying logger, for the few APIs that take one
 // directly.
 func (l Logger) GetSlogLogger() *log.Logger {
-	return l.unwrap()
+	return l.Logger
 }
 
 // GetLogger returns a logr view of this logger, for libraries that accept only
 // logr — controller-runtime's manager.Options.Logger in particular.
 func (l Logger) GetLogger() logr.Logger {
-	return logr.FromSlogHandler(l.unwrap().Handler())
-}
-
-// Error logs at error level. The error is attached as a structured field via
-// log.Err, and the underlying logger appends a full stack trace.
-//
-// This one delegates to the library instead of going through emit, because the
-// stack trace is injected by log.Logger.Error itself. The trace supersedes the
-// "source" field, which the handler drops when a trace is present, so nothing is
-// lost by not fixing up the caller frame here.
-func (l Logger) Error(err error, message string, keysAndValues ...interface{}) {
-	l.unwrap().Error(message, append([]any{log.Err(err)}, keysAndValues...)...)
-}
-
-func (l Logger) Warning(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelWarn, message, keysAndValues)
-}
-
-func (l Logger) Info(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelInfo, message, keysAndValues)
-}
-
-func (l Logger) Debug(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelDebug, message, keysAndValues)
+	return logr.FromSlogHandler(l.Handler())
 }
 
 // Trace logs at the trace level, which plain slog does not provide.
-func (l Logger) Trace(message string, keysAndValues ...interface{}) {
-	l.emit(log.LevelTrace, message, keysAndValues)
-}
-
-// emit builds the record by hand so that the "source" field names the call site
-// rather than this file.
 //
-// Calling log.Logger.Info and friends directly would make slog capture the
-// program counter of the wrapper, so every line would report
-// logger/logger.go. The previous klog-based logger avoided that with
-// WithCallDepth(1); this is the slog equivalent.
-func (l Logger) emit(level log.Level, message string, keysAndValues []any) {
-	lg := l.unwrap()
+// Info, Debug, Warn and Error come from the embedded logger, so slog attributes
+// them to their call site by itself. Trace is a method on this type, so the
+// record is built by hand to keep "source" pointing at the caller instead of this
+// file.
+func (l Logger) Trace(message string, args ...any) {
 	ctx := context.Background()
-	slevel := slog.Level(level)
+	level := slog.Level(log.LevelTrace)
 
-	if !lg.Enabled(ctx, slevel) {
+	if !l.Enabled(ctx, level) {
 		return
 	}
 
-	// Skip runtime.Callers, emit itself, and the exported method that called it.
+	// Skip runtime.Callers, Trace itself, and land on the caller.
 	var pcs [1]uintptr
-	runtime.Callers(3, pcs[:])
+	runtime.Callers(2, pcs[:])
 
-	record := slog.NewRecord(time.Now(), slevel, message, pcs[0])
-	record.Add(keysAndValues...)
+	record := slog.NewRecord(time.Now(), level, message, pcs[0])
+	record.Add(args...)
 
 	// The error is not actionable: the handler only fails if the record cannot be
 	// serialised, and there is nowhere left to report that.
-	_ = lg.Handler().Handle(ctx, record)
+	_ = l.Handler().Handle(ctx, record)
 }

--- a/images/webhooks/pkg/logger/logger_test.go
+++ b/images/webhooks/pkg/logger/logger_test.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"bytes"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -28,7 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-func newBufLogger(t *testing.T, level Verbosity) (*Logger, *bytes.Buffer) {
+func newBufLogger(t *testing.T, level Verbosity) (Logger, *bytes.Buffer) {
 	t.Helper()
 
 	buf := &bytes.Buffer{}
@@ -112,8 +113,8 @@ func TestLevelThresholds(t *testing.T) {
 		t.Run(string(tt.level), func(t *testing.T) {
 			l, buf := newBufLogger(t, tt.level)
 
-			l.Error(errors.New("boom"), "an-error")
-			l.Warning("a-warning")
+			l.Error("an-error", Err(errors.New("boom")))
+			l.Warn("a-warning")
 			l.Info("an-info")
 			l.Debug("a-debug")
 			l.Trace("a-trace")
@@ -132,7 +133,7 @@ func TestLevelThresholds(t *testing.T) {
 func TestErrorAttachesErrorAndStackTrace(t *testing.T) {
 	l, buf := newBufLogger(t, TraceLevel)
 
-	l.Error(errors.New("disk on fire"), "unable to create volume", "volumeID", "pvc-123")
+	l.Error("unable to create volume", Err(errors.New("disk on fire")), slog.String("volumeID", "pvc-123"))
 
 	out := buf.String()
 	assert.Contains(t, out, "unable to create volume")
@@ -149,7 +150,7 @@ func TestErrorToleratesNilError(t *testing.T) {
 
 	// Call sites pass whatever they hold; a nil error must not panic.
 	assert.NotPanics(t, func() {
-		l.Error(nil, "something went wrong")
+		l.Error("something went wrong", Err(nil))
 	})
 	assert.Contains(t, buf.String(), "something went wrong")
 }
@@ -196,7 +197,7 @@ func TestSetLevelChangesLevelInPlace(t *testing.T) {
 
 	// Changing the level must affect the live logger, which is what lets the
 	// level be raised without restarting the pod.
-	require.NoError(t, l.SetLevel(DebugLevel))
+	require.NoError(t, l.SetVerbosity(DebugLevel))
 	l.Debug("after")
 	assert.Contains(t, buf.String(), "after")
 }
@@ -208,7 +209,7 @@ func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
 	child.Debug("before")
 	require.NotContains(t, buf.String(), "before")
 
-	require.NoError(t, l.SetLevel(DebugLevel))
+	require.NoError(t, l.SetVerbosity(DebugLevel))
 
 	child.Debug("after")
 	assert.Contains(t, buf.String(), "after")
@@ -216,51 +217,51 @@ func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
 
 func TestSetLevelRejectsInvalidValue(t *testing.T) {
 	l, _ := newBufLogger(t, InfoLevel)
-	assert.Error(t, l.SetLevel(Verbosity("nonsense")))
+	assert.Error(t, l.SetVerbosity(Verbosity("nonsense")))
 }
 
 func TestNopDiscardsEverything(t *testing.T) {
 	l := NewNop()
 
 	assert.NotPanics(t, func() {
-		l.Error(errors.New("boom"), "an-error")
+		l.Error("an-error", Err(errors.New("boom")))
 		l.Info("an-info")
 		l.Trace("a-trace")
 		l.Named("x").With("k", "v").Debug("a-debug")
 	})
 }
 
-// TestZeroLoggerIsANoOp guards the behaviour the previous logr-backed
-// implementation had: tests construct logger.Logger{} directly and must not
-// crash on it.
-func TestZeroLoggerIsANoOp(t *testing.T) {
-	var l Logger
+// TestNopIsUsableEverywhere covers what the zero value used to be relied on for.
+// Embedding *log.Logger means the zero Logger can no longer be a silent no-op, so
+// callers that want one ask for NewNop instead.
+func TestNopIsUsableEverywhere(t *testing.T) {
+	l := NewNop()
 
 	assert.NotPanics(t, func() {
-		l.Error(errors.New("boom"), "an-error")
-		l.Warning("a-warning")
+		l.Error("an-error", Err(errors.New("boom")))
+		l.Warn("a-warning")
 		l.Info("an-info")
 		l.Debug("a-debug")
 		l.Trace("a-trace")
 		l.Named("x").With("k", "v").Info("nested")
 		_ = l.GetLogger()
 		_ = l.GetSlogLogger()
-		_ = l.SetLevel(InfoLevel)
+		_ = l.SetVerbosity(InfoLevel)
 	})
 }
 
-// TestSourceNamesTheCallSite guards against the wrapper attributing every record
-// to itself. Without the manual record construction in emit, "source" would read
-// logger/logger.go for all 300-odd call sites in the module.
+// TestSourceNamesTheCallSite guards caller attribution. Info/Debug/Warn come
+// straight from the embedded logger so slog attributes them itself; Trace is a
+// method on this type and builds its record by hand to achieve the same.
 func TestSourceNamesTheCallSite(t *testing.T) {
 	tests := []struct {
 		name string
-		emit func(l *Logger)
+		emit func(l Logger)
 	}{
-		{name: "Warning", emit: func(l *Logger) { l.Warning("m") }},
-		{name: "Info", emit: func(l *Logger) { l.Info("m") }},
-		{name: "Debug", emit: func(l *Logger) { l.Debug("m") }},
-		{name: "Trace", emit: func(l *Logger) { l.Trace("m") }},
+		{name: "Warn", emit: func(l Logger) { l.Warn("m") }},
+		{name: "Info", emit: func(l Logger) { l.Info("m") }},
+		{name: "Debug", emit: func(l Logger) { l.Debug("m") }},
+		{name: "Trace", emit: func(l Logger) { l.Trace("m") }},
 	}
 
 	for _, tt := range tests {
@@ -282,7 +283,7 @@ func TestSourceNamesTheCallSite(t *testing.T) {
 func TestErrorReportsStackTraceInsteadOfSource(t *testing.T) {
 	l, buf := newBufLogger(t, TraceLevel)
 
-	l.Error(errors.New("boom"), "failed")
+	l.Error("failed", Err(errors.New("boom")))
 
 	out := buf.String()
 	assert.NotContains(t, out, `"source"`)

--- a/images/webhooks/pkg/logger/logger_test.go
+++ b/images/webhooks/pkg/logger/logger_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+func newBufLogger(t *testing.T, level Verbosity) (*Logger, *bytes.Buffer) {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	l, err := NewLoggerToWriter(buf, level)
+	require.NoError(t, err)
+	return l, buf
+}
+
+func TestVerbosityLevelMapping(t *testing.T) {
+	// The numeric LOG_LEVEL contract is shared with lib-helm and the CSI
+	// templates; these thresholds must keep matching the previous klog-based
+	// logger, where Warning was V(1), Info V(2), Debug V(3) and Trace V(4).
+	tests := []struct {
+		verbosity Verbosity
+		want      log.Level
+	}{
+		{verbosity: ErrorLevel, want: log.LevelError},
+		{verbosity: WarningLevel, want: log.LevelWarn},
+		{verbosity: InfoLevel, want: log.LevelInfo},
+		{verbosity: DebugLevel, want: log.LevelDebug},
+		{verbosity: TraceLevel, want: log.LevelTrace},
+		// Anything past TRACE stays at TRACE, as before.
+		{verbosity: Verbosity("9"), want: log.LevelTrace},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.verbosity), func(t *testing.T) {
+			got, err := tt.verbosity.Level()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVerbosityRejectsInvalidValues(t *testing.T) {
+	for _, v := range []Verbosity{"", "abc", "-1", "2.5"} {
+		t.Run(string(v), func(t *testing.T) {
+			_, err := v.Level()
+			assert.Error(t, err)
+
+			_, err = NewLogger(v)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestLevelThresholds pins which methods emit at each configured verbosity.
+func TestLevelThresholds(t *testing.T) {
+	tests := []struct {
+		level   Verbosity
+		emitted []string
+		dropped []string
+	}{
+		{
+			level:   ErrorLevel,
+			emitted: []string{"an-error"},
+			dropped: []string{"a-warning", "an-info", "a-debug", "a-trace"},
+		},
+		{
+			level:   WarningLevel,
+			emitted: []string{"an-error", "a-warning"},
+			dropped: []string{"an-info", "a-debug", "a-trace"},
+		},
+		{
+			level:   InfoLevel,
+			emitted: []string{"an-error", "a-warning", "an-info"},
+			dropped: []string{"a-debug", "a-trace"},
+		},
+		{
+			level:   DebugLevel,
+			emitted: []string{"an-error", "a-warning", "an-info", "a-debug"},
+			dropped: []string{"a-trace"},
+		},
+		{
+			level:   TraceLevel,
+			emitted: []string{"an-error", "a-warning", "an-info", "a-debug", "a-trace"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.level), func(t *testing.T) {
+			l, buf := newBufLogger(t, tt.level)
+
+			l.Error(errors.New("boom"), "an-error")
+			l.Warning("a-warning")
+			l.Info("an-info")
+			l.Debug("a-debug")
+			l.Trace("a-trace")
+
+			out := buf.String()
+			for _, msg := range tt.emitted {
+				assert.Contains(t, out, msg, "%s should be emitted at %s", msg, tt.level)
+			}
+			for _, msg := range tt.dropped {
+				assert.NotContains(t, out, msg, "%s should be dropped at %s", msg, tt.level)
+			}
+		})
+	}
+}
+
+func TestErrorAttachesErrorAndStackTrace(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Error(errors.New("disk on fire"), "unable to create volume", "volumeID", "pvc-123")
+
+	out := buf.String()
+	assert.Contains(t, out, "unable to create volume")
+	// The error travels as a structured field rather than being interpolated
+	// into the message.
+	assert.Contains(t, out, "disk on fire")
+	assert.Contains(t, out, "pvc-123")
+	// A stack trace is what the previous logger did not provide.
+	assert.Contains(t, out, "logger.TestErrorAttachesErrorAndStackTrace")
+}
+
+func TestErrorToleratesNilError(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	// Call sites pass whatever they hold; a nil error must not panic.
+	assert.NotPanics(t, func() {
+		l.Error(nil, "something went wrong")
+	})
+	assert.Contains(t, buf.String(), "something went wrong")
+}
+
+func TestNamedBuildsDottedPath(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Named("local-storage-class-controller").Named("reconcile").Info("starting")
+
+	// This is the replacement for hand-written "[Component]" message prefixes.
+	assert.Contains(t, buf.String(), "local-storage-class-controller.reconcile")
+}
+
+func TestNamedDoesNotAffectTheParent(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	child := l.Named("child")
+	child.Info("from-child")
+	l.Info("from-parent")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "child")
+	assert.NotContains(t, lines[1], "child")
+}
+
+func TestWithAttachesFieldsToEveryRecord(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	scoped := l.With("traceID", "abc-123", "volumeID", "pvc-1")
+	scoped.Info("first")
+	scoped.Trace("second")
+
+	out := buf.String()
+	assert.Equal(t, 2, strings.Count(out, "abc-123"))
+	assert.Equal(t, 2, strings.Count(out, "pvc-1"))
+}
+
+func TestSetLevelChangesLevelInPlace(t *testing.T) {
+	l, buf := newBufLogger(t, ErrorLevel)
+
+	l.Debug("before")
+	require.NotContains(t, buf.String(), "before")
+
+	// Changing the level must affect the live logger, which is what lets the
+	// level be raised without restarting the pod.
+	require.NoError(t, l.SetLevel(DebugLevel))
+	l.Debug("after")
+	assert.Contains(t, buf.String(), "after")
+}
+
+func TestSetLevelPropagatesToDerivedLoggers(t *testing.T) {
+	l, buf := newBufLogger(t, ErrorLevel)
+	child := l.Named("child").With("k", "v")
+
+	child.Debug("before")
+	require.NotContains(t, buf.String(), "before")
+
+	require.NoError(t, l.SetLevel(DebugLevel))
+
+	child.Debug("after")
+	assert.Contains(t, buf.String(), "after")
+}
+
+func TestSetLevelRejectsInvalidValue(t *testing.T) {
+	l, _ := newBufLogger(t, InfoLevel)
+	assert.Error(t, l.SetLevel(Verbosity("nonsense")))
+}
+
+func TestNopDiscardsEverything(t *testing.T) {
+	l := NewNop()
+
+	assert.NotPanics(t, func() {
+		l.Error(errors.New("boom"), "an-error")
+		l.Info("an-info")
+		l.Trace("a-trace")
+		l.Named("x").With("k", "v").Debug("a-debug")
+	})
+}
+
+// TestZeroLoggerIsANoOp guards the behaviour the previous logr-backed
+// implementation had: tests construct logger.Logger{} directly and must not
+// crash on it.
+func TestZeroLoggerIsANoOp(t *testing.T) {
+	var l Logger
+
+	assert.NotPanics(t, func() {
+		l.Error(errors.New("boom"), "an-error")
+		l.Warning("a-warning")
+		l.Info("an-info")
+		l.Debug("a-debug")
+		l.Trace("a-trace")
+		l.Named("x").With("k", "v").Info("nested")
+		_ = l.GetLogger()
+		_ = l.GetSlogLogger()
+		_ = l.SetLevel(InfoLevel)
+	})
+}
+
+// TestSourceNamesTheCallSite guards against the wrapper attributing every record
+// to itself. Without the manual record construction in emit, "source" would read
+// logger/logger.go for all 300-odd call sites in the module.
+func TestSourceNamesTheCallSite(t *testing.T) {
+	tests := []struct {
+		name string
+		emit func(l *Logger)
+	}{
+		{name: "Warning", emit: func(l *Logger) { l.Warning("m") }},
+		{name: "Info", emit: func(l *Logger) { l.Info("m") }},
+		{name: "Debug", emit: func(l *Logger) { l.Debug("m") }},
+		{name: "Trace", emit: func(l *Logger) { l.Trace("m") }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, buf := newBufLogger(t, TraceLevel)
+
+			tt.emit(l)
+
+			out := buf.String()
+			assert.Contains(t, out, "logger_test.go")
+			assert.NotContains(t, out, "logger/logger.go")
+		})
+	}
+}
+
+// TestErrorReportsStackTraceInsteadOfSource documents the one exception: the
+// handler drops "source" when a stack trace is attached, so Error does not need
+// caller fix-up.
+func TestErrorReportsStackTraceInsteadOfSource(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	l.Error(errors.New("boom"), "failed")
+
+	out := buf.String()
+	assert.NotContains(t, out, `"source"`)
+	assert.Contains(t, out, "stacktrace")
+}
+
+func TestGetLoggerBridgesToLogr(t *testing.T) {
+	l, buf := newBufLogger(t, TraceLevel)
+
+	// controller-runtime takes a logr.Logger; records written through it must
+	// land in the same output with the same level handling.
+	l.GetLogger().Info("from-logr", "k", "v")
+
+	out := buf.String()
+	assert.Contains(t, out, "from-logr")
+	assert.Contains(t, out, "\"k\":\"v\"")
+}

--- a/templates/controller/controller.yaml
+++ b/templates/controller/controller.yaml
@@ -5,6 +5,24 @@
 }}
 {{ include "helm_lib_module_webhook_certs_secret" (list . $secretConfig) }}
 
+{{- /*
+  The webhooks container takes its log level as a flag, because
+  helm_lib_module_controller_manifests injects no env into it but does allow the
+  command to be overridden. The value is the same numeric verbosity the
+  controller gets through LOG_LEVEL.
+
+  Overriding the command means restating the TLS flags, so the cert mount path is
+  set explicitly here and reused, rather than relying on the lib-helm default
+  matching the literal below.
+*/ -}}
+{{- $webhooksCertMountPath := "/etc/webhook/certs" }}
+{{- $webhooksCommand := list
+  "/webhooks"
+  (printf "-tls-cert-file=%s/tls.crt" $webhooksCertMountPath)
+  (printf "-tls-key-file=%s/tls.key" $webhooksCertMountPath)
+  (printf "-log-level=%s" (include "helm_lib_module_controller_log_level" (list . "sdsLocalVolume")))
+}}
+
 {{- /* Controller Deployment */ -}}
 {{- $config := dict
   "valuesKey" "sdsLocalVolume"
@@ -13,6 +31,8 @@
   "onMasterNode" true
   "podSecurityContext" "deckhouse"
   "controllerMetricsPort" 8080
+  "webhooksCertMountPath" $webhooksCertMountPath
+  "webhooksCommand" $webhooksCommand
 }}
 {{ include "helm_lib_module_controller_manifests" (list . $config) }}
 


### PR DESCRIPTION
> **Stacked on #253** (which is stacked on #252). Base is `feat/metrics-storage`, so the diff here is only this PR's own commit. Merge order: #252 → #253 → #254 → #255.

## What

The module ran **four** logging stacks at once:

| Component | Stack | Level |
|---|---|---|
| controller | klog `textlogger` via its own `pkg/logger` | `LOG_LEVEL` |
| sds-local-volume-csi | klog `textlogger` via a **copy** of `pkg/logger` | `LOG_LEVEL` |
| webhooks | `sirupsen/logrus` | **hard-coded to Debug** |
| everywhere | 30 direct `klog.*` calls, 7 writes to stderr via `fmt` | — |

The two copies of `pkg/logger` had already drifted — only one had `NewLoggerFromLogr`. Output format, level handling and the meaning of `LOG_LEVEL` differed per component.

This reimplements `pkg/logger` on [`deckhouse/pkg/log`](https://github.com/deckhouse/deckhouse/tree/main/pkg/log), keeping the `Error/Warning/Info/Debug/Trace` method set so **the ~360 existing call sites are untouched**. The copies in `images/controller` and `images/sds-local-volume-csi` are now byte-identical, and `images/webhooks` gains the same package.

## LOG_LEVEL compatibility

`LOG_LEVEL` arrives as a **number 0..4**, produced both by lib-helm's `helm_lib_module_controller_log_level` and by the module's own CSI templates. That contract is unchanged: the old `V(1)`/`V(2)`/`V(3)`/`V(4)` thresholds map onto warn/info/debug/trace, so a given `LOG_LEVEL` keeps emitting exactly the same set of messages. A table test pins each threshold.

## What the new logger adds

One JSON format across all components, `Named()` for a dotted component path, `With()` for per-unit-of-work fields, a real Trace level, `SetLevel()` that retunes a live logger and everything derived from it, a full stack trace on `Error`, and `NewNop`/`NewLoggerToWriter` for tests.

Two behaviours preserved deliberately, both covered by tests:

- **The zero `Logger` stays a silent no-op.** The previous implementation held a `logr.Logger` by value, whose zero value discards, and tests construct `logger.Logger{}` directly.
- **`source` names the call site.** Records are built by hand in `emit()`; calling slog through a wrapper would otherwise attribute every line to `logger.go`, losing what the old `WithCallDepth(1)` gave. `Error` is exempt — the handler drops `source` when a stack trace is present.

## Bugs fixed

Four latent logging bugs where a format string was passed as the message with its arguments landing in `keysAndValues`, so the value became a **key** and the data was replaced by `(MISSING)`:

```
I0729 08:03:01 proc.go:290] "INFO [...] starts Reconcile for the LocalStorageClass %s" my-sc-name="(MISSING)"
```

- `local_storage_class_watcher.go` — reconcile start and end
- `pkg/utils/func.go` — `DeleteVolume`
- `controller_snapshots_ee.go` — end of `Snapshot`

**Webhook crash.** `LSCValidate` called `klog.Fatal` on a failure to build the kube client or to list `LVMVolumeGroup`s, so one transient API error exited the process and took admission down for **every** request until the pod restarted (this is item 4 of `REVIEW.md`). Both now log and fail just that request. To make this possible the validators became constructors taking a logger instead of bare functions.

Also: the three `fmt.Print` debug leftovers in `driver.Run` that bypassed the logger and the configured level became a Trace record.

## webhooks

`logrus` is gone. kubewebhook's logger interface is satisfied by a ~40-line adapter, since upstream ships one for logrus only. The level now comes from the module's `logLevel` through a `-log-level` flag rather than being hard-coded to Debug — `helm_lib_module_controller_manifests` injects no env into that container but does allow overriding its command, so the chart passes it there. The cert mount path is set explicitly and reused so the overridden command cannot drift from the volume mount.

## sloglint

Enabled, with an honest note in the config about its reach: sloglint and govet's slog analyzer recognise `log/slog` and types embedding `*slog.Logger`, so they cover the logger package and any direct `pkg/log` use, **but not calls through the `logger.Logger` wrapper**. The follow-up PR removes the wrapper for exactly that reason.

## Verification

- `go build` / `go vet` / `go test` green for all three modules, including `-tags integration` and all three editions
- `golangci-lint`: 0 issues everywhere
- `helm template` asserted at `logLevel` INFO/TRACE/ERROR: the webhooks container receives the same numeric level as the controller (`-log-level=2/4/0`), and the command's TLS paths match the mounted cert volume

## Notes for the reviewer

- Expect **more log volume**: `Error` now attaches a full stack trace, and there are ~110 `Error` call sites, some on transient errors (`unable to list`, update conflicts). Worth a look on dev before rollout.
- `scValidator` still dumps whole StorageClass objects at Info on every update. Left alone here to keep this commit behaviour-preserving; the follow-up PR moves it to Debug.
- Rebase onto #253 (metrics) — they touch the same files.