### PR TITLE
feat: make the snapshot-controller dependency optional

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Available access modes for the module: RWO.
 {{< /alert >}}
 
 {{< alert level="warning" >}}
-The [snapshot-controller](/modules/snapshot-controller/) module must be connected for this module to operate. The ability to work with volume snapshots is available only in commercial editions of Deckhouse Kubernetes Platform and only when using LVM-thin volumes.
+Volume snapshots require a module that provides the `snapshot.storage.k8s.io` CRDs, for example [snapshot-controller](/modules/snapshot-controller/). The ability to work with volume snapshots is available only in commercial editions of Deckhouse Kubernetes Platform and only when using LVM-thin volumes.
 {{< /alert >}}
 
 ## How the module works

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -13,7 +13,7 @@ weight: 1
 {{< /alert >}}
 
 {{< alert level="warning" >}}
-Для работы модуля требуется подключенный модуль [snapshot-controller](/modules/snapshot-controller/). Возможность работы со снимками томов доступна только в коммерческих редакциях Deckhouse Kubernetes Platform и только при использовании LVM-thin томов.
+Для снимков томов требуется модуль, поставляющий CRD группы `snapshot.storage.k8s.io`, — например [snapshot-controller](/modules/snapshot-controller/). Возможность работы со снимками томов доступна только в коммерческих редакциях Deckhouse Kubernetes Platform и только при использовании LVM-thin томов.
 {{< /alert >}}
 
 ## Как работает модуль

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -124,7 +124,7 @@ echo "Data migration completed"
 {{< alert level="warning" >}}
 The ability to work with volume snapshots is available only in commercial editions of Deckhouse Kubernetes Platform and only when using LVM-thin volumes.
 
-The [snapshot-controller](/modules/snapshot-controller/) module must be connected for this module to operate.
+A module that provides the `snapshot.storage.k8s.io` CRDs, for example [snapshot-controller](/modules/snapshot-controller/), must be connected for snapshots to work.
 {{< /alert >}}
 
 For detailed information about snapshots, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).

--- a/docs/USAGE.ru.md
+++ b/docs/USAGE.ru.md
@@ -124,7 +124,7 @@ echo "Data migration completed"
 {{< alert level="warning" >}}
 Возможность работы со снимками томов доступна только в коммерческих редакциях Deckhouse Kubernetes Platform и только при использовании LVM-thin томов.
 
-Для работы модуля требуется подключенный модуль [snapshot-controller](/modules/snapshot-controller/).
+Для работы снимков требуется подключенный модуль, поставляющий CRD группы `snapshot.storage.k8s.io`, — например [snapshot-controller](/modules/snapshot-controller/).
 {{< /alert >}}
 
 Подробную информацию о снимках см. в [документации Kubernetes](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).

--- a/module.yaml
+++ b/module.yaml
@@ -9,5 +9,4 @@ requirements:
   deckhouse: ">= 1.72"
   modules:
     sds-node-configurator: ">= 0.6.1"
-    snapshot-controller: ">= 0.0.0"
 namespace: d8-sds-local-volume

--- a/templates/csi/volume-snapshot-class.yaml
+++ b/templates/csi/volume-snapshot-class.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "snapshot-controller") }}
+{{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshotClass" }}
 ---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass


### PR DESCRIPTION
## Description

Removes the hard `snapshot-controller` dependency and replaces it with a runtime check for the snapshot CRDs.

- `module.yaml`: dropped the `requirements.modules.snapshot-controller` entry (`sds-node-configurator` stays).
- `templates/csi/volume-snapshot-class.yaml`: gated on `.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshotClass"` instead of `.Values.global.enabledModules | has "snapshot-controller"`.
- Docs (EN + RU, README and USAGE): the "snapshot-controller must be connected for this module to operate" wording now scopes the requirement to volume snapshots.

No controller changes — `sds-local-volume` creates no VolumeSnapshotClass from Go code.

No changes to critical cluster components; no restarts of ingress-controllers, control-plane or Prometheus.

## Why do we need it, and what problem does it solve?

`snapshot-controller` is no longer the only module shipping the `snapshot.storage.k8s.io` CRDs — `storage-foundation` ships them too, and `snapshot-controller`'s own templates already stand down when `storage-foundation` is enabled. A hard `requirements.modules` entry on `snapshot-controller` therefore blocks `sds-local-volume` in clusters where the CRDs are present but come from somewhere else, and forces the module on users who do not need snapshots at all.

Gating on the CRD instead of on the module name makes the dependency describe what the code actually needs.

## What is the expected result?

- With the snapshot CRDs installed (from any module): unchanged behaviour — `sds-local-volume-snapshot-class` is rendered exactly as before.
- Without the snapshot CRDs: `sds-local-volume` enables and works normally; the `VolumeSnapshotClass` is simply not rendered. Nothing else in the release changes.
- Installing a module that provides the CRDs afterwards: the next Helm release renders the class.
- `sds-local-volume` can be enabled in a cluster where `snapshot-controller` is disabled, which Deckhouse previously rejected.

Verified with `helm template`: the template renders nothing without the API and the full `VolumeSnapshotClass` with `--api-versions snapshot.storage.k8s.io/v1/VolumeSnapshotClass`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
