### PR TITLE
fix(status): truncate the condition message to what the schema allows

### DIFF
--- a/images/controller/pkg/controller/local_storage_class_watcher_func.go
+++ b/images/controller/pkg/controller/local_storage_class_watcher_func.go
@@ -791,6 +791,16 @@ func publishLocalStorageClassStatus(
 	phase,
 	reason string,
 ) error {
+	// The schema caps the message at 32768, and the callers pass err.Error()
+	// straight through — an error carrying a command's output or an aggregate
+	// of per-node failures reaches that. Over the cap the API server rejects
+	// the whole status write, so the resource would keep reporting its previous
+	// verdict and the reconcile would fail on the write rather than on what
+	// actually went wrong. conditions.Set does not truncate: it is a thin
+	// wrapper over meta.SetStatusCondition, and only the library's Ready and
+	// ReadyWithMessage builders truncate for you.
+	cond.Message = conditions.TruncateMessage(cond.Message)
+
 	apply := func(sc *slv.LocalStorageClass) {
 		if sc.Status == nil {
 			sc.Status = new(slv.LocalStorageClassStatus)

--- a/images/controller/pkg/controller/status_conditions_test.go
+++ b/images/controller/pkg/controller/status_conditions_test.go
@@ -419,7 +419,10 @@ func TestUpdateLocalStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) 
 	// length, counted in runes, and TruncateMessage counts the same way — a
 	// byte-counting assertion here would fail on a message that is in fact
 	// within the limit.
-	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
+	//
+	// Written as an escape rather than the character itself: the module linter
+	// rejects non-ASCII bytes in Go sources.
+	huge := strings.Repeat("\u044f", conditions.MaxMessageLen+100)
 	if err := updateLocalStorageClassPhase(context.Background(), cl, lsc, FailedStatusPhase, huge); err != nil {
 		t.Fatalf("updateLocalStorageClassPhase: %v", err)
 	}

--- a/images/controller/pkg/controller/status_conditions_test.go
+++ b/images/controller/pkg/controller/status_conditions_test.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -414,7 +415,11 @@ func TestUpdateLocalStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) 
 	}
 	cl := newStatusTestClient(t, lsc)
 
-	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+	// Multi-byte on purpose. The schema's maxLength is an OpenAPI string
+	// length, counted in runes, and TruncateMessage counts the same way — a
+	// byte-counting assertion here would fail on a message that is in fact
+	// within the limit.
+	huge := strings.Repeat("я", conditions.MaxMessageLen+100)
 	if err := updateLocalStorageClassPhase(context.Background(), cl, lsc, FailedStatusPhase, huge); err != nil {
 		t.Fatalf("updateLocalStorageClassPhase: %v", err)
 	}
@@ -423,15 +428,19 @@ func TestUpdateLocalStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) 
 	if ready == nil {
 		t.Fatal("Ready condition was not published")
 	}
-	if len(ready.Message) > conditions.MaxMessageLen {
-		t.Errorf("message is %d bytes, over the %d the schema allows",
-			len(ready.Message), conditions.MaxMessageLen)
+	// Counted in runes, not bytes: the schema's maxLength is an OpenAPI string
+	// length, which the API server validates with utf8.RuneCountInString, and
+	// TruncateMessage counts the same way. Measuring len() would fail this test
+	// on any non-ASCII message that is in fact within the limit.
+	if utf8.RuneCountInString(ready.Message) > conditions.MaxMessageLen {
+		t.Errorf("message is %d runes, over the %d the schema allows",
+			utf8.RuneCountInString(ready.Message), conditions.MaxMessageLen)
 	}
 
 	// The caller's copy is mirrored from the same condition, so it must not
 	// carry the untruncated message either.
 	mirrored := conditions.Get(lsc.Status.Conditions, slv.ConditionTypeReady)
-	if mirrored == nil || len(mirrored.Message) > conditions.MaxMessageLen {
+	if mirrored == nil || utf8.RuneCountInString(mirrored.Message) > conditions.MaxMessageLen {
 		t.Errorf("the mirrored condition was not truncated: %+v", mirrored)
 	}
 }

--- a/images/controller/pkg/controller/status_conditions_test.go
+++ b/images/controller/pkg/controller/status_conditions_test.go
@@ -404,6 +404,38 @@ func TestUpdateLocalStorageClassPhase_DoesNotReviveTheFinalizerWhileDeleting(t *
 	}
 }
 
+// The failure paths pass err.Error() through as the condition message, and the
+// schema caps it at 32768. Over the cap the API server rejects the whole status
+// write, so the resource keeps reporting its previous verdict and the reconcile
+// fails on the write instead of on what actually went wrong.
+func TestUpdateLocalStorageClassPhase_TruncatesAnOversizedMessage(t *testing.T) {
+	lsc := &slv.LocalStorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: testLSCName, Generation: 1},
+	}
+	cl := newStatusTestClient(t, lsc)
+
+	huge := strings.Repeat("x", conditions.MaxMessageLen+100)
+	if err := updateLocalStorageClassPhase(context.Background(), cl, lsc, FailedStatusPhase, huge); err != nil {
+		t.Fatalf("updateLocalStorageClassPhase: %v", err)
+	}
+
+	ready := conditions.Get(readLSC(t, cl).Status.Conditions, slv.ConditionTypeReady)
+	if ready == nil {
+		t.Fatal("Ready condition was not published")
+	}
+	if len(ready.Message) > conditions.MaxMessageLen {
+		t.Errorf("message is %d bytes, over the %d the schema allows",
+			len(ready.Message), conditions.MaxMessageLen)
+	}
+
+	// The caller's copy is mirrored from the same condition, so it must not
+	// carry the untruncated message either.
+	mirrored := conditions.Get(lsc.Status.Conditions, slv.ConditionTypeReady)
+	if mirrored == nil || len(mirrored.Message) > conditions.MaxMessageLen {
+		t.Errorf("the mirrored condition was not truncated: %+v", mirrored)
+	}
+}
+
 // A LocalStorageClass whose teardown is blocked used to keep advertising
 // Ready=True from its last successful pass, which is precisely the state an
 // alert on "Ready=False for longer than N minutes" is meant to catch.


### PR DESCRIPTION
## Description

The controller builds its `Ready` condition by hand and passes `err.Error()` through as the message. The CRD caps `message` at 32768 — the limit `metav1.Condition` itself declares, applied when the conditions schema was tightened. Nothing between the two truncates.

`conditions.Set` looks like it would, but it does not: it is a thin wrapper over `meta.SetStatusCondition`. Only the library's `Ready` and `ReadyWithMessage` builders call `TruncateMessage`, and this module does not use them.

The fix truncates at the single point where a condition reaches the API server, so it covers the existing callers and any added later.

## Why do we need it, and what problem does it solve?

An oversized message does not get trimmed by the API server — the whole status write is rejected. Three things follow, in order of how confusing they are:

1. The resource keeps advertising its **previous** verdict. A `Ready=True` from the last successful pass survives the failure that should have replaced it, so an alert on `Ready=False` never fires for exactly the failure that produced the most output.
2. The reconcile fails on the status write rather than on the underlying problem, so the log names an admission error instead of the thing that actually broke.
3. It is self-reinforcing: the longer the error, the more certain it is to be lost.

The errors that reach this length are the ones worth reading — an aggregate over many nodes, or a command's captured output.

## What is the expected result?

A failure whose message exceeds 32768 is published with the message truncated to the cap (the library appends an ellipsis), `Ready=False` and `reason: ReconcileFailed`, instead of the status write being rejected.

Unchanged: `status.reason`, which the schema does not limit, still carries the full text; the debug logs still print it untruncated; messages under the cap are byte-for-byte what they were.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
